### PR TITLE
examples: switch to registry.k8s.io

### DIFF
--- a/examples/loadbalancer_etp_cluster.yaml
+++ b/examples/loadbalancer_etp_cluster.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: agnhost
-        image: k8s.gcr.io/e2e-test-images/agnhost:2.40
+        image: registry.k8s.io/e2e-test-images/agnhost:2.40
         args:
           - netexec
           - --http-port=8080

--- a/examples/loadbalancer_etp_local.yaml
+++ b/examples/loadbalancer_etp_local.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: agnhost
-        image: k8s.gcr.io/e2e-test-images/agnhost:2.40
+        image: registry.k8s.io/e2e-test-images/agnhost:2.40
         args:
           - netexec
           - --http-port=8080


### PR DESCRIPTION
k8s.gcr.io is deprecated. See: https://kubernetes.io/blog/2022/11/28/registry-k8s-io-faster-cheaper-ga/