### PR TITLE
Run CCM inside a container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,6 @@ COPY . .
 RUN make build
 
 # build real cloud-provider-kind image
-FROM gcr.io/distroless/static-debian12
+FROM docker:25.0-dind
 COPY --from=0 --chown=root:root ./go/src/bin/cloud-provider-kind /bin/cloud-provider-kind
 ENTRYPOINT ["/bin/cloud-provider-kind"]

--- a/README.md
+++ b/README.md
@@ -40,7 +40,10 @@ the docker socket inside the container:
 
 ```sh
 docker build . -t aojea/cloud-provider-kind:v0.1
+# using the host network
 docker run --rm --network host -v /var/run/docker.sock:/var/run/docker.sock aojea/cloud-provider-kind:v0.1
+# or the kind network
+docker run --rm --network kind  -v /var/run/docker.sock:/var/run/docker.sock aojea/cloud-provider-kind:v0.1
 ```
 
 ## How to use it

--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ cd cloud-provider-kind && make
 sudo mv .bin//cloud-provider-kind  /usr/local/bin/cloud-provider-kind
 ```
 
+Another alternative is to run it as a container, but this will require to mount
+the docker socket inside the container:
+
+```sh
+docker build . -t aojea/cloud-provider-kind:v0.1
+docker run --rm --network host -v /var/run/docker.sock:/var/run/docker.sock aojea/cloud-provider-kind:v0.1
+```
+
 ## How to use it
 
 Run a KIND cluster:

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -107,10 +107,9 @@ func (c *Controller) Run(ctx context.Context) {
 	}
 }
 
-// getKubeClient returns the corresponding kubeclient
-// this is needed because the controller can run inside the docker network,
-// hence it will need the internal kubeconfig, or can run outside on the host,
-// hence it will need the external kubeconfig
+// getKubeClient returns a kubeclient depending if the ccm runs inside a container
+// inside the same docker network that the kind cluster or run externally in the host
+// It tries first to connect to the external endpoint
 func (c *Controller) getKubeClient(ctx context.Context, cluster string) (kubernetes.Interface, error) {
 	httpClient := &http.Client{
 		Timeout: 5 * time.Second,
@@ -119,7 +118,7 @@ func (c *Controller) getKubeClient(ctx context.Context, cluster string) (kuberne
 		},
 	}
 	// try internal first
-	for _, internal := range []bool{true, false} {
+	for _, internal := range []bool{false, true} {
 		kconfig, err := c.kind.KubeConfig(cluster, internal)
 		if err != nil {
 			klog.Errorf("Failed to get kubeconfig for cluster %s: %v", cluster, err)

--- a/pkg/loadbalancer/proxy.go
+++ b/pkg/loadbalancer/proxy.go
@@ -17,7 +17,7 @@ import (
 )
 
 // proxyImage defines the loadbalancer image:tag
-const proxyImage = "kindest/haproxy:v20230330-2f738c2"
+const proxyImage = "docker.io/kindest/haproxy:v20230606-42a2262b"
 
 // proxyConfigPath defines the path to the config file in the image
 const proxyConfigPath = "/usr/local/etc/haproxy/haproxy.cfg"


### PR DESCRIPTION
Allow to run ccm both inside or outside of the kind network, so it is simpler to deploy just running a docker container instead of having to run the binary