### PR TITLE
Added name length cap for loadbalancer name

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -8,4 +8,6 @@ const (
 	FixedNetworkName = "kind"
 	// NodeCCMLabelKey
 	NodeCCMLabelKey = "io.x-k8s.cloud-provider-kind.cluster"
+	// NodeNameLabelKey
+	NodeNameLabelKey = "io.x-k8s.cloud-provider-kind.node.name"
 )

--- a/pkg/loadbalancer/server_test.go
+++ b/pkg/loadbalancer/server_test.go
@@ -1,0 +1,39 @@
+package loadbalancer
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/cloud-provider-kind/pkg/constants"
+)
+
+func TestLoadBalancerName(t *testing.T) {
+	tests := []struct {
+		name        string
+		cluster     string
+		service     *v1.Service
+		expected    string
+		expectedLen int
+	}{
+		{
+			name:        "simple",
+			cluster:     "test-cluster",
+			service:     &v1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: "test-namespace", Name: "test-service"}},
+			expected:    constants.ContainerPrefix + "-AWEHRL6IVEFOWQI2DXZDWR4QZPCNHGSVJCV5UBM6",
+			expectedLen: 48,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := loadBalancerName(test.cluster, test.service)
+			if actual != test.expected {
+				t.Errorf("expected %q, got %q", test.expected, actual)
+			}
+			if len(actual) != test.expectedLen {
+				t.Errorf("expected length %d, got %d", test.expectedLen, len(actual))
+			}
+		})
+	}
+}


### PR DESCRIPTION
This change truncates the loadbalancer name to 63 characters max and ensures there are no trailing dots, dashes, or underscores. 

/fixes #35 