### PR TITLE
Add the command to add an IP to an interface on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,15 +176,16 @@ on the host.
 
 Limitations:
 
-- Windows not supported yet.
 - Mutation of Services, adding or removing ports to an existing Services, is not supported.
 - cloud-provider-kind binary needs permissions to add IP address to interfaces and to listen on privileged ports.
 - Overlapping IP between the containers and the host can break connectivity.
 
+Mainly tested with `docker` and `Linux`, though `Windows` and `Mac` are also basically supported:
+- On macOS you must run cloud-provider-kind using `sudo`
+- On Windows you must run cloud-provider-kind from a shell that uses `Run as administrator`
+- Further feedback from users will be helpful to support other related platforms.
 
 **Note**
-
-Only tested with `docker` and `Linux`, but `podman` and `Windows` and `Mac`users feedback will be helpful to support those platforms.
 
 The project is still in very alpha state, bugs are expected, please report them back opening a Github issue.
 

--- a/pkg/loadbalancer/address_windows.go
+++ b/pkg/loadbalancer/address_windows.go
@@ -2,12 +2,22 @@
 
 package loadbalancer
 
-import "fmt"
+import (
+	"os/exec"
+)
 
 func AddIPToInterface(ifaceName string, ip string) error {
-	return fmt.Errorf(("not implemented"))
+	err := exec.Command("netsh", "interface", "ip", "add", "address", "loopback", ip, "255.255.255.255").Run()
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func RemoveIPToInterface(ifaceName string, ip string) error {
-	return fmt.Errorf(("not implemented"))
+	err := exec.Command("netsh", "interface", "ip", "delete", "address", "loopback", ip, "255.255.255.255").Run()
+	if err != nil {
+		return err
+	}
+	return nil
 }


### PR DESCRIPTION
This PR was discussed in [issue 44](https://github.com/kubernetes-sigs/cloud-provider-kind/issues/44) with @aojea and contains the update we discussed together.

I have tested on Windows 11 and the changes worked fine, so this improves the Windows support to the same level as macOS.