### PR TITLE
Enable docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,18 @@ Another alternative is to run it as a container, but this will require to mount
 the docker socket inside the container:
 
 ```sh
-docker build . -t aojea/cloud-provider-kind:v0.1
+docker build . -t cloud-provider-kind
 # using the host network
-docker run --rm --network host -v /var/run/docker.sock:/var/run/docker.sock aojea/cloud-provider-kind:v0.1
+docker run --rm --network host -v /var/run/docker.sock:/var/run/docker.sock cloud-provider-kind
 # or the kind network
-docker run --rm --network kind  -v /var/run/docker.sock:/var/run/docker.sock aojea/cloud-provider-kind:v0.1
+docker run --rm --network kind -v /var/run/docker.sock:/var/run/docker.sock cloud-provider-kind
+```
+
+Or using `compose.yaml` file:
+
+```sh
+# using the `kind` network (`host` is the default value for NET_MODE)
+NET_MODE=kind docker compose up -d
 ```
 
 ## How to use it

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,6 @@
+services:
+  cloud-provider:
+    build: .
+    network_mode: "${NET_MODE-host}"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
Utilizing `docker-compose` tool can reduce the number of instructions used to deploy the cloud provider service.