### PR TITLE
[WIP] KEP-1860 Make Kubernetes aware of the LoadBalancer behaviour

### DIFF
--- a/pkg/loadbalancer/server.go
+++ b/pkg/loadbalancer/server.go
@@ -14,6 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	cloudprovider "k8s.io/cloud-provider"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/cloud-provider-kind/pkg/constants"
 	"sigs.k8s.io/cloud-provider-kind/pkg/container"
 )
@@ -65,10 +66,17 @@ func (s *Server) GetLoadBalancer(ctx context.Context, clusterName string, servic
 		}
 	}
 	if ipv4 != "" && svcIPv4 {
-		status.Ingress = append(status.Ingress, v1.LoadBalancerIngress{IP: ipv4, Ports: portStatus})
+		status.Ingress = append(status.Ingress, v1.LoadBalancerIngress{
+			IP:     ipv4,
+			Ports:  portStatus,
+			IPMode: ptr.To(v1.LoadBalancerIPModeProxy),
+		})
 	}
 	if ipv6 != "" && svcIPv6 {
-		status.Ingress = append(status.Ingress, v1.LoadBalancerIngress{IP: ipv6, Ports: portStatus})
+		status.Ingress = append(status.Ingress, v1.LoadBalancerIngress{
+			IP:     ipv6,
+			Ports:  portStatus,
+			IPMode: ptr.To(v1.LoadBalancerIPModeProxy)})
 	}
 
 	return status, true, nil


### PR DESCRIPTION
Spotted by @danwinship in https://github.com/kubernetes/kubernetes/pull/124660#issuecomment-2094268703

Since cloud-provider-kind implement a loadbalancer in proxy mode, it should add the respective field.

The problem is that this field was beta in 1.30, so it will break on old clusters ... we must add a check like we did in the past for endpointslices, to obtain the version of the kubernetes cluster and add this field only for the supported versions.

This will also help to the graduation of the KEP, as it will be tested in the CI https://github.com/kubernetes/enhancements/tree/master/keps/sig-network/1860-kube-proxy-IP-node-binding