### PR TITLE
solve UDP crashes

### DIFF
--- a/pkg/loadbalancer/proxy.go
+++ b/pkg/loadbalancer/proxy.go
@@ -238,6 +238,7 @@ func generateConfig(service *v1.Service, nodes []*v1.Node) *proxyConfigData {
 	return lbConfig
 }
 
+// TODO: move to xDS via GRPC instead of having to deal with files
 func proxyUpdateLoadBalancer(ctx context.Context, clusterName string, service *v1.Service, nodes []*v1.Node) error {
 	if service == nil {
 		return nil
@@ -270,7 +271,7 @@ func proxyUpdateLoadBalancer(ctx context.Context, clusterName string, service *v
 	// envoy has an initialization process until starts to forward traffic
 	// https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/operations/init#arch-overview-initialization
 	// also wait for the healthchecks and "no_traffic_interval"
-	cmd := fmt.Sprintf(`chmod a+r /home/envoy/* && mv %s %s && mv %s %s`, proxyConfigPathCDS+".tmp", proxyConfigPathCDS, proxyConfigPathLDS+".tmp", proxyConfigPathLDS)
+	cmd := fmt.Sprintf(`chmod a+rw /home/envoy/* && mv %s %s && mv %s %s`, proxyConfigPathCDS+".tmp", proxyConfigPathCDS, proxyConfigPathLDS+".tmp", proxyConfigPathLDS)
 	err = container.Exec(name, []string{"bash", "-c", cmd}, nil, &stdout, &stderr)
 	if err != nil {
 		return fmt.Errorf("error updating configuration Stdout: %s Stderr: %s : %w", stdout.String(), stderr.String(), err)

--- a/pkg/loadbalancer/server.go
+++ b/pkg/loadbalancer/server.go
@@ -197,7 +197,7 @@ func (s *Server) createLoadBalancer(clusterName string, service *v1.Service, ima
 		// including some ones docker would otherwise do by default.
 		// for now this is what we want. in the future we may revisit this.
 		"--privileged",
-		"--restart=on-failure:1",                    // to allow to change the configuration
+		"--restart=on-failure",                      // to deal with the crash casued by https://github.com/envoyproxy/envoy/issues/34195
 		"--sysctl=net.ipv4.ip_forward=1",            // allow ip forwarding
 		"--sysctl=net.ipv6.conf.all.disable_ipv6=0", // enable IPv6
 		"--sysctl=net.ipv6.conf.all.forwarding=1",   // allow ipv6 forwarding


### PR DESCRIPTION
This restarts the loadbalancer container when it crashes because of https://github.com/envoyproxy/envoy/issues/34195

Apparently on the restart it works fine and the test goes through.

There are a lot of hacks to deal with files and the user id for the container command is different than the one to update them, so during the restart it fails to touch the config files, since we are not worried by security on these envoys I just give them a+rw  .... the goal is to move to dynamic configuration using GRPC https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/operations/dynamic_configuration so this hack will serve until then