### PR TITLE
Use the envoy admin port to detect when the loadbalancer is ready to accept connections

### DIFF
--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -157,8 +157,8 @@ func PortMaps(name string) (map[string]string, error) {
 		if len(parts) == 2 {
 			protocol = strings.ToLower(parts[1])
 		}
-		if protocol != "tcp" {
-			klog.Infof("skipping protocol %s not supported, only TCP", protocol)
+		if protocol != "tcp" && protocol != "udp" {
+			klog.Infof("skipping protocol %s not supported, only UDP and TCP", protocol)
 			continue
 		}
 

--- a/pkg/loadbalancer/proxy.go
+++ b/pkg/loadbalancer/proxy.go
@@ -45,7 +45,7 @@ admin:
   address:
     socket_address:
       address: 0.0.0.0
-      port_value: 9901
+      port_value: 10000
 `
 
 // proxyConfigData is supplied to the loadbalancer config template

--- a/pkg/loadbalancer/proxy.go
+++ b/pkg/loadbalancer/proxy.go
@@ -19,11 +19,12 @@ import (
 // proxyImage defines the loadbalancer image:tag
 const proxyImage = "envoyproxy/envoy:v1.30.1"
 
-// proxyConfigPath defines the path to the config files in the image
+// keep in sync with dynamicFilesystemConfig
 const (
 	proxyConfigPath    = "/home/envoy/envoy.yaml"
 	proxyConfigPathCDS = "/home/envoy/cds.yaml"
 	proxyConfigPathLDS = "/home/envoy/lds.yaml"
+	envoyAdminPort     = 10000
 )
 
 // start Envoy with dynamic configuration by using files that implement the xDS protocol.

--- a/pkg/loadbalancer/proxy.go
+++ b/pkg/loadbalancer/proxy.go
@@ -234,7 +234,7 @@ func generateConfig(service *v1.Service, nodes []*v1.Node) *proxyConfigData {
 		}
 	}
 	lbConfig.ServicePorts = servicePortConfig
-	klog.V(2).Infof("haproxy config info: %+v", lbConfig)
+	klog.V(2).Infof("envoy config info: %+v", lbConfig)
 	return lbConfig
 }
 

--- a/pkg/loadbalancer/server.go
+++ b/pkg/loadbalancer/server.go
@@ -212,9 +212,9 @@ func (s *Server) createLoadBalancer(clusterName string, service *v1.Service, ima
 			}
 			args = append(args, fmt.Sprintf("--publish=%d/%s", port.Port, "TCP"))
 		}
-		// Publish all ports in the host in random ports
-		args = append(args, "--publish-all")
 	}
+	// Publish all ports in the host in random ports
+	args = append(args, "--publish-all")
 
 	args = append(args, image)
 	// we need to override the default envoy configuration

--- a/pkg/loadbalancer/server.go
+++ b/pkg/loadbalancer/server.go
@@ -207,7 +207,7 @@ func (s *Server) createLoadBalancer(clusterName string, service *v1.Service, ima
 	if s.tunnelManager != nil {
 		// Forward the Service Ports to the host so they are accessible on Mac and Windows
 		for _, port := range service.Spec.Ports {
-			if port.Protocol != v1.ProtocolTCP {
+			if port.Protocol != v1.ProtocolTCP && port.Protocol != v1.ProtocolUDP {
 				continue
 			}
 			args = append(args, fmt.Sprintf("--publish=%d/%s", port.Port, port.Protocol))

--- a/pkg/loadbalancer/server.go
+++ b/pkg/loadbalancer/server.go
@@ -210,9 +210,11 @@ func (s *Server) createLoadBalancer(clusterName string, service *v1.Service, ima
 			if port.Protocol != v1.ProtocolTCP {
 				continue
 			}
-			args = append(args, fmt.Sprintf("--publish=%d/%s", port.Port, "TCP"))
+			args = append(args, fmt.Sprintf("--publish=%d/%s", port.Port, port.Protocol))
 		}
 	}
+	// publish the admin endpoint
+	args = append(args, fmt.Sprintf("--publish=%d/%s", envoyAdminPort, v1.ProtocolTCP))
 	// Publish all ports in the host in random ports
 	args = append(args, "--publish-all")
 


### PR DESCRIPTION
Instead of waiting a random time do active polling to check the state of the envoy container, this will also help to detect containers restarts