### PR TITLE
adding ability to output loadbalancer status changes

### DIFF
--- a/cmd/app.go
+++ b/cmd/app.go
@@ -18,15 +18,17 @@ import (
 )
 
 var (
-	flagV         int
-	enableLogDump bool
-	logDumpDir    string
+	flagV                    int
+	enableLogDump            bool
+	logDumpDir               string
+	enableLoadBalancerStatus bool
 )
 
 func init() {
 	flag.IntVar(&flagV, "v", 2, "Verbosity level")
 	flag.BoolVar(&enableLogDump, "enable-log-dumping", false, "store logs to a temporal directory or to the directory specified using the logs-dir flag")
 	flag.StringVar(&logDumpDir, "logs-dir", "", "store logs to the specified directory")
+	flag.BoolVar(&enableLoadBalancerStatus, "enable-load-balancer-status", false, "output in json the loadbalancer status to stdout")
 
 	flag.Usage = func() {
 		fmt.Fprint(os.Stderr, "Usage: cloud-provider-kind [options]\n\n")
@@ -97,6 +99,6 @@ func Main() {
 		config.DefaultConfig.LogDir = logDumpDir
 		klog.Infof("**** Dumping load balancers logs to: %s", logDumpDir)
 	}
-
+	config.DefaultConfig.EnableLoadBalancerStatus = enableLoadBalancerStatus
 	controller.New(logger).Run(ctx)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -5,6 +5,7 @@ package config
 var DefaultConfig = &Config{}
 
 type Config struct {
-	EnableLogDump bool
-	LogDir        string
+	EnableLogDump            bool
+	LogDir                   string
+	EnableLoadBalancerStatus bool
 }


### PR DESCRIPTION
Wanting to be able to watch for updates to loadbalancers so added flag to send output to system out in json format to be able to parse.  

Interested to see if there is a better way to do this where process running this binary can react to status changes for loadbalancers added/removed.