### PR TITLE
Use fully qualified image name for envoy proxy image

### DIFF
--- a/pkg/loadbalancer/proxy.go
+++ b/pkg/loadbalancer/proxy.go
@@ -21,7 +21,7 @@ import (
 )
 
 // proxyImage defines the loadbalancer image:tag
-const proxyImage = "envoyproxy/envoy:v1.30.1"
+const proxyImage = "docker.io/envoyproxy/envoy:v1.30.1"
 
 // keep in sync with dynamicFilesystemConfig
 const (


### PR DESCRIPTION
This should fix an issue where `docker.io` might not be in the list of `unqualified-search-registries` when using Podman.

This _might_ be the root cause for #116.