### PR TITLE
Fix load balancer readiness checks when running inside a container.

### DIFF
--- a/pkg/loadbalancer/server.go
+++ b/pkg/loadbalancer/server.go
@@ -22,14 +22,17 @@ import (
 )
 
 type Server struct {
+	directConnectivity bool
 	tunnelManager *tunnelManager
 }
 
 var _ cloudprovider.LoadBalancer = &Server{}
 
-func NewServer() cloudprovider.LoadBalancer {
-	s := &Server{}
-	if runtime.GOOS == "darwin" || runtime.GOOS == "windows" || isWSL2() {
+func NewServer(directConnectivity bool) cloudprovider.LoadBalancer {
+	s := &Server{
+		directConnectivity: directConnectivity,
+	}
+	if directConnectivity || runtime.GOOS == "darwin" || runtime.GOOS == "windows" || isWSL2() {
 		s.tunnelManager = NewTunnelManager()
 	}
 	return s
@@ -145,7 +148,7 @@ func (s *Server) EnsureLoadBalancer(ctx context.Context, clusterName string, ser
 }
 
 func (s *Server) UpdateLoadBalancer(ctx context.Context, clusterName string, service *v1.Service, nodes []*v1.Node) error {
-	return proxyUpdateLoadBalancer(ctx, clusterName, service, nodes)
+	return proxyUpdateLoadBalancer(ctx, clusterName, service, nodes, s.directConnectivity)
 }
 
 func (s *Server) EnsureLoadBalancerDeleted(ctx context.Context, clusterName string, service *v1.Service) error {

--- a/pkg/provider/cloud.go
+++ b/pkg/provider/cloud.go
@@ -9,11 +9,11 @@ import (
 	"sigs.k8s.io/kind/pkg/cluster"
 )
 
-func New(clusterName string, kindClient *cluster.Provider) cloudprovider.Interface {
+func New(clusterName string, kindClient *cluster.Provider, directConnectivity bool) cloudprovider.Interface {
 	return &cloud{
 		clusterName:  clusterName,
 		kindClient:   kindClient,
-		lbController: loadbalancer.NewServer(),
+		lbController: loadbalancer.NewServer(directConnectivity),
 	}
 }
 


### PR DESCRIPTION
I encountered the issues reported in #109. However, because I am running the system on macOS, using the `--network host` option when launching the "cloud-provider-kind" container doesn't work. Use of the "kind" defined network is required in order for the "cloud-provider-kind" container to successfully [communicate](https://github.com/kubernetes-sigs/cloud-provider-kind/blob/a384948631c160bf5c9732c01bff0641c224f400/pkg/controller/controller.go#L123) with the Kind Kubernetes controller (i.e. `internal` must be `true` - I suspect that the [comment](https://github.com/kubernetes-sigs/cloud-provider-kind/blob/a384948631c160bf5c9732c01bff0641c224f400/pkg/controller/controller.go#L121) is incorrect, `internal == false` is tried first…):
```
11:24:12.042101       1 app.go:41] FLAG: --enable-log-dumping="false"
11:24:12.042161       1 app.go:41] FLAG: --logs-dir=""
11:24:12.042168       1 app.go:41] FLAG: --v="2"
11:24:12.266173       1 controller.go:166] probe HTTP address https://127.0.0.1:51518
11:24:12.266644       1 controller.go:169] Failed to connect to HTTP address https://127.0.0.1:51518: Get "https://127.0.0.1:51518": dial tcp 127.0.0.1:51518: connect: connection refused
11:24:12.266711       1 controller.go:166] probe HTTP address https://127.0.0.1:51518
11:24:12.267021       1 controller.go:169] Failed to connect to HTTP address https://127.0.0.1:51518: Get "https://127.0.0.1:51518": dial tcp 127.0.0.1:51518: connect: connection refused
11:24:13.270465       1 controller.go:166] probe HTTP address https://127.0.0.1:51518
11:24:13.271440       1 controller.go:169] Failed to connect to HTTP address https://127.0.0.1:51518: Get "https://127.0.0.1:51518": dial tcp 127.0.0.1:51518: connect: connection refused
11:24:15.272618       1 controller.go:166] probe HTTP address https://127.0.0.1:51518
11:24:15.273070       1 controller.go:169] Failed to connect to HTTP address https://127.0.0.1:51518: Get "https://127.0.0.1:51518": dial tcp 127.0.0.1:51518: connect: connection refused
11:24:18.275251       1 controller.go:166] probe HTTP address https://127.0.0.1:51518
11:24:18.275680       1 controller.go:169] Failed to connect to HTTP address https://127.0.0.1:51518: Get "https://127.0.0.1:51518": dial tcp 127.0.0.1:51518: connect: connection refused
11:24:22.276154       1 controller.go:151] Failed to connect to apiserver kind: <nil>
11:24:22.370267       1 controller.go:166] probe HTTP address https://kind-control-plane:6443
11:24:22.376355       1 controller.go:83] Creating new cloud provider for cluster kind
11:24:22.382101       1 controller.go:90] Starting cloud controller for cluster kind
```

The proposed changes seek to identify if/when the system is executing within a container. There doesn't appear to be a great universal way of achieving this, so I went with defining a `container` environment variable within the Dockerfile, inspired by [systemd's Container Interface specification](https://systemd.io/CONTAINER_INTERFACE/#environment-variables). An alternative approach might be to pass a command-line [flag](https://pkg.go.dev/flag), but plumbing such a value through to where it's required seemed non-trivial. I also found it necessary to enable the [tunnelManager](https://github.com/kubernetes-sigs/cloud-provider-kind/blob/a384948631c160bf5c9732c01bff0641c224f400/pkg/loadbalancer/server.go#L32L34) implementation for the case where the system is running on Linux within a container.