### PR TITLE
support different platforms and connectivity scenarios

### DIFF
--- a/cmd/app.go
+++ b/cmd/app.go
@@ -21,15 +21,17 @@ import (
 )
 
 var (
-	flagV         int
-	enableLogDump bool
-	logDumpDir    string
+	flagV               int
+	enableLogDump       bool
+	logDumpDir          string
+	enableLBPortMapping bool
 )
 
 func init() {
 	flag.IntVar(&flagV, "v", 2, "Verbosity level")
 	flag.BoolVar(&enableLogDump, "enable-log-dumping", false, "store logs to a temporal directory or to the directory specified using the logs-dir flag")
 	flag.StringVar(&logDumpDir, "logs-dir", "", "store logs to the specified directory")
+	flag.BoolVar(&enableLBPortMapping, "enable-lb-port-mapping", false, "enable port-mapping on the load balancer ports")
 
 	flag.Usage = func() {
 		fmt.Fprint(os.Stderr, "Usage: cloud-provider-kind [options]\n\n")
@@ -104,6 +106,11 @@ func Main() {
 	// some platforms require to enable tunneling for the LoadBalancers
 	if runtime.GOOS == "darwin" || runtime.GOOS == "windows" || isWSL2() {
 		config.DefaultConfig.LoadBalancerConnectivity = config.Tunnel
+	}
+
+	// flag overrides autodetection
+	if enableLBPortMapping {
+		config.DefaultConfig.LoadBalancerConnectivity = config.Portmap
 	}
 
 	// default control plane connectivity to portmap, it will be

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -7,4 +7,20 @@ var DefaultConfig = &Config{}
 type Config struct {
 	EnableLogDump bool
 	LogDir        string
+	// Platforms like Mac or Windows can not access the containers directly
+	// so we do a double hop, enable container portmapping for the LoadBalancer containter
+	// and do userspace proxying from the original port to the portmaps.
+	// If the cloud-provider-kind runs in a container on these platforms only enables portmapping.
+	LoadBalancerConnectivity Connectivity
+	// Type of connectivity between the cloud-provider-kind and the clusters
+	ControlPlaneConnectivity Connectivity
 }
+
+type Connectivity int
+
+const (
+	Unknown Connectivity = iota
+	Direct
+	Portmap
+	Tunnel
+)

--- a/pkg/loadbalancer/server.go
+++ b/pkg/loadbalancer/server.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"runtime"
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
@@ -29,18 +28,11 @@ var _ cloudprovider.LoadBalancer = &Server{}
 
 func NewServer() cloudprovider.LoadBalancer {
 	s := &Server{}
-	if runtime.GOOS == "darwin" || runtime.GOOS == "windows" || isWSL2() {
+
+	if config.DefaultConfig.LoadBalancerConnectivity == config.Tunnel {
 		s.tunnelManager = NewTunnelManager()
 	}
 	return s
-}
-
-func isWSL2() bool {
-	if v, err := os.ReadFile("/proc/version"); err == nil {
-		return strings.Contains(string(v), "WSL2")
-	}
-
-	return false
 }
 
 func (s *Server) GetLoadBalancer(ctx context.Context, clusterName string, service *v1.Service) (*v1.LoadBalancerStatus, bool, error) {

--- a/pkg/loadbalancer/server.go
+++ b/pkg/loadbalancer/server.go
@@ -220,7 +220,8 @@ func (s *Server) createLoadBalancer(clusterName string, service *v1.Service, ima
 		}...)
 	}
 
-	if s.tunnelManager != nil {
+	if s.tunnelManager != nil ||
+		config.DefaultConfig.LoadBalancerConnectivity == config.Portmap {
 		// Forward the Service Ports to the host so they are accessible on Mac and Windows
 		for _, port := range service.Spec.Ports {
 			if port.Protocol != v1.ProtocolTCP && port.Protocol != v1.ProtocolUDP {


### PR DESCRIPTION
These are these combinations

- Two type of platforms: containers reachable (Linux) or not reachable from host (Mac, Windows they run in a VM )
- Two type of deployments: cloud-provider-kind as a container or as a proces.

1. Containers Reachable and KCCM Process: Direct (Linux) (autodetected)
2. Containers Reachable and KCCM container: Direct (Linux) (autodetected)
3. Containers Not Reachable and KCCM Process: Tunnel (Mac, Windows, WSL2) (autodetected)
4. Containers Not Reachable and KCCM Container: Portmap (Mac, Windows, WSL2) (set via flag)

Fixes: #109 