### PR TITLE
Prompt user if process running on Mac not under sudo

### DIFF
--- a/cmd/app.go
+++ b/cmd/app.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"os/user"
 	"runtime"
 	"strconv"
 	"strings"
@@ -45,6 +46,15 @@ func Main() {
 	flag.VisitAll(func(flag *flag.Flag) {
 		klog.Infof("FLAG: --%s=%q", flag.Name, flag.Value)
 	})
+
+	// Process on macOS must run using sudo
+	if runtime.GOOS == "darwin" {
+		currentUser, _ := user.Current()
+		if currentUser.Uid != "0" {
+			fmt.Println("Please run this again with `sudo`.")
+			os.Exit(1)
+		}
+	}
 
 	// trap Ctrl+C and call cancel on the context
 	ctx := context.Background()

--- a/cmd/app.go
+++ b/cmd/app.go
@@ -48,7 +48,7 @@ func Main() {
 
 	// Process on macOS must run using sudo
 	if runtime.GOOS == "darwin" && syscall.Geteuid() != 0 {
-		klog.Warning("Please run this again with `sudo`.")
+		klog.Fatalf("Please run this again with `sudo`.")
 	}
 
 	// trap Ctrl+C and call cancel on the context

--- a/cmd/app.go
+++ b/cmd/app.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
-	"os/user"
 	"runtime"
 	"strconv"
 	"strings"
@@ -48,12 +47,8 @@ func Main() {
 	})
 
 	// Process on macOS must run using sudo
-	if runtime.GOOS == "darwin" {
-		currentUser, _ := user.Current()
-		if currentUser.Uid != "0" {
-			fmt.Println("Please run this again with `sudo`.")
-			os.Exit(1)
-		}
+	if runtime.GOOS == "darwin" && syscall.Geteuid() != 0 {
+		klog.Warning("Please run this again with `sudo`.")
 	}
 
 	// trap Ctrl+C and call cancel on the context


### PR DESCRIPTION
On macOS, cloud-provider-kind requires sudo because it relies on Docker's port mapping to expose the LoadBalancer's IP and ports to the host, and this network configuration requires root privileges. issue: https://github.com/kubernetes-sigs/cloud-provider-kind/issues/117