### PR TITLE
Fix exclude label docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,6 @@ you will need to remove this label to access them using a LoadBalancer:
 
 ```sh
 $ kubectl label node kind-control-plane node.kubernetes.io/exclude-from-external-load-balancers-
-node/kind-control-plane unlabeled
 ```
 
 Once the cluster is running, we need to run the `cloud-provider-kind` in a terminal and keep it running. The `cloud-provider-kind` will monitor all your KIND clusters and `Services` with Type `LoadBalancer` and create the corresponding LoadBalancer containers that will expose those Services.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,12 @@ Have a question, bug, or feature request? Let us know! https://kind.sigs.k8s.io/
 
 **Note**
 
-Control-plane nodes need to remove the special label `node.kubernetes.io/exclude-from-external-load-balancers` to be able to access the workloads running on those nodes using a LoadBalancer Service.
+By default, [Kubernetes expects workloads will not run on control plane nodes](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/#control-plane-node-isolation)
+and labels them with [`node.kubernetes.io/exclude-from-external-load-balancers`](https://kubernetes.io/docs/reference/labels-annotations-taints/#node-kubernetes-io-exclude-from-external-load-balancers),
+which stops load balancers from accessing them.
+
+If you are running workloads on control plane nodes, as is the [default kind configuration](https://kind.sigs.k8s.io/docs/user/configuration/#nodes),
+you will need to remove this label to access them using a LoadBalancer:
 
 ```sh
 $ kubectl label node kind-control-plane node.kubernetes.io/exclude-from-external-load-balancers-

--- a/README.md
+++ b/README.md
@@ -7,12 +7,11 @@ KIND has demonstrated to be a very versatile, efficient, cheap and very useful t
 - [Slack channel](https://kubernetes.slack.com/messages/kind)
 - [Mailing list](https://groups.google.com/forum/#!forum/kubernetes-sig-testing)
 
-## Talks 
+## Talks
 
 Kubecon EU 2024 - [Keep Calm and Load Balance on KIND - Antonio Ojea & Benjamin Elder, Google](https://sched.co/1YhhY)
 
 [![Keep Calm and Load Balance on KIND](https://img.youtube.com/vi/U6_-y24rJnI/0.jpg)](https://www.youtube.com/watch?v=U6_-y24rJnI)
-
 
 ## Install
 
@@ -131,14 +130,14 @@ spec:
         app: MyLocalApp
     spec:
       containers:
-      - name: agnhost
-        image: registry.k8s.io/e2e-test-images/agnhost:2.40
-        args:
-          - netexec
-          - --http-port=8080
-          - --udp-port=8080
-        ports:
-        - containerPort: 8080
+        - name: agnhost
+          image: registry.k8s.io/e2e-test-images/agnhost:2.40
+          args:
+            - netexec
+            - --http-port=8080
+            - --udp-port=8080
+          ports:
+            - containerPort: 8080
 ---
 apiVersion: v1
 kind: Service
@@ -191,6 +190,7 @@ Limitations:
 - Overlapping IP between the containers and the host can break connectivity.
 
 Mainly tested with `docker` and `Linux`, though `Windows` and `Mac` are also basically supported:
+
 - On macOS you must run cloud-provider-kind using `sudo`
 - On Windows you must run cloud-provider-kind from a shell that uses `Run as administrator`
 - Further feedback from users will be helpful to support other related platforms.

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Have a question, bug, or feature request? Let us know! https://kind.sigs.k8s.io/
 
 ```
 
-**Note**
+### Allowing load balancers access to control plane nodes
 
 By default, [Kubernetes expects workloads will not run on control plane nodes](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/create-cluster-kubeadm/#control-plane-node-isolation)
 and labels them with [`node.kubernetes.io/exclude-from-external-load-balancers`](https://kubernetes.io/docs/reference/labels-annotations-taints/#node-kubernetes-io-exclude-from-external-load-balancers),
@@ -99,6 +99,8 @@ you will need to remove this label to access them using a LoadBalancer:
 ```sh
 $ kubectl label node kind-control-plane node.kubernetes.io/exclude-from-external-load-balancers-
 ```
+
+### Running the provider
 
 Once the cluster is running, we need to run the `cloud-provider-kind` in a terminal and keep it running. The `cloud-provider-kind` will monitor all your KIND clusters and `Services` with Type `LoadBalancer` and create the corresponding LoadBalancer containers that will expose those Services.
 


### PR DESCRIPTION
This PR address two issues about the README raised in https://github.com/kubernetes-sigs/cloud-provider-kind/issues/144:
* The wording around removing the `node.kubernetes.io/exclude-from-external-load-balancers` label can be confusing for less experienced users.
  * This PR adds additional detail and links to external documentation.
* The provided command to remove the label from the default kind node can be difficult to run for less experienced users.
  * This PR removes the output line, so the command can be copied directly.
 
Also included are:
  * Small formatting changes to the README to bring it in line with standard markdown formatting guidelines.
  * Additional section headings around the referenced section to more clearly delineate logical areas.
  
Happy to make any required adjustments. Thanks for providing this excellent tool!