### PR TITLE
Use a shorter hash for the container name

### DIFF
--- a/pkg/loadbalancer/server.go
+++ b/pkg/loadbalancer/server.go
@@ -163,7 +163,7 @@ func (s *Server) EnsureLoadBalancerDeleted(ctx context.Context, clusterName stri
 func loadBalancerName(clusterName string, service *v1.Service) string {
 	hash := sha256.Sum256([]byte(loadBalancerSimpleName(clusterName, service)))
 	encoded := base32.StdEncoding.EncodeToString(hash[:])
-	name := constants.ContainerPrefix + "-" + encoded[:40]
+	name := constants.ContainerPrefix + "-" + encoded[:16]
 
 	return name
 }

--- a/pkg/loadbalancer/server.go
+++ b/pkg/loadbalancer/server.go
@@ -162,7 +162,10 @@ func (s *Server) EnsureLoadBalancerDeleted(ctx context.Context, clusterName stri
 // loadbalancer name is a unique name for the loadbalancer container
 func loadBalancerName(clusterName string, service *v1.Service) string {
 	h := sha256.New()
-	io.WriteString(h, loadBalancerSimpleName(clusterName, service))
+	_, err := io.WriteString(h, loadBalancerSimpleName(clusterName, service))
+	if err != nil {
+		panic(err)
+	}
 	hash := h.Sum(nil)
 	return fmt.Sprintf("%s-%x", constants.ContainerPrefix, hash[:6])
 }

--- a/pkg/loadbalancer/server.go
+++ b/pkg/loadbalancer/server.go
@@ -3,9 +3,9 @@ package loadbalancer
 import (
 	"context"
 	"crypto/sha256"
-	"encoding/base32"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path"
 	"strings"
@@ -161,11 +161,10 @@ func (s *Server) EnsureLoadBalancerDeleted(ctx context.Context, clusterName stri
 
 // loadbalancer name is a unique name for the loadbalancer container
 func loadBalancerName(clusterName string, service *v1.Service) string {
-	hash := sha256.Sum256([]byte(loadBalancerSimpleName(clusterName, service)))
-	encoded := base32.StdEncoding.EncodeToString(hash[:])
-	name := constants.ContainerPrefix + "-" + encoded[:16]
-
-	return name
+	h := sha256.New()
+	io.WriteString(h, loadBalancerSimpleName(clusterName, service))
+	hash := h.Sum(nil)
+	return fmt.Sprintf("%s-%x", constants.ContainerPrefix, hash[:6])
 }
 
 func loadBalancerSimpleName(clusterName string, service *v1.Service) string {

--- a/pkg/loadbalancer/server_test.go
+++ b/pkg/loadbalancer/server_test.go
@@ -20,8 +20,8 @@ func TestLoadBalancerName(t *testing.T) {
 			name:        "simple",
 			cluster:     "test-cluster",
 			service:     &v1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: "test-namespace", Name: "test-service"}},
-			expected:    constants.ContainerPrefix + "-CGVXJAVBASN2Z3RXOABMYVHNP7WNHR3ATSDVOTEN",
-			expectedLen: 48,
+			expected:    constants.ContainerPrefix + "-11ab7482a104",
+			expectedLen: 20,
 		},
 	}
 


### PR DESCRIPTION
`docker inspect -f {{range .NetworkSettings.Networks}}{{.IPAddress}},{{.GlobalIPv6Address}}{{end}} kindccm-RZTQCN5REF5VESVEBSRFF5NKA2S54JVJFWGT3EOM , with kindccm-... the current container (we should replace such long string for something shorter)`

Fixes: #190 