### PR TITLE
fix(tunnel): propagate half-closed TCP connections

### DIFF
--- a/pkg/loadbalancer/tunnel.go
+++ b/pkg/loadbalancer/tunnel.go
@@ -120,7 +120,8 @@ func NewTunnel(localIP, localPort, protocol, remoteIP, remotePort string) *tunne
 
 func (t *tunnel) Start() error {
 	klog.Infof("Starting tunnel on %s %s", net.JoinHostPort(t.localIP, t.localPort), t.protocol)
-	if t.protocol == "udp" {
+	switch t.protocol {
+	case "udp":
 		localAddrStr := net.JoinHostPort(t.localIP, t.localPort)
 		udpAddr, err := net.ResolveUDPAddr("udp4", localAddrStr)
 		if err != nil {
@@ -136,8 +137,7 @@ func (t *tunnel) Start() error {
 				}
 			}
 		}()
-
-	} else if t.protocol == "tcp" || t.protocol == "tcp4" || t.protocol == "tcp6" {
+	case "tcp", "tcp4", "tcp6":
 		ln, err := net.Listen(t.protocol, net.JoinHostPort(t.localIP, t.localPort))
 		if err != nil {
 			return err
@@ -166,7 +166,7 @@ func (t *tunnel) Start() error {
 				}()
 			}
 		}()
-	} else {
+	default:
 		return fmt.Errorf("unsupported protocol %s", t.protocol)
 	}
 	return nil

--- a/pkg/loadbalancer/tunnel.go
+++ b/pkg/loadbalancer/tunnel.go
@@ -137,7 +137,7 @@ func (t *tunnel) Start() error {
 			}
 		}()
 
-	} else {
+	} else if t.protocol == "tcp" || t.protocol == "tcp4" || t.protocol == "tcp6" {
 		ln, err := net.Listen(t.protocol, net.JoinHostPort(t.localIP, t.localPort))
 		if err != nil {
 			return err
@@ -151,16 +151,23 @@ func (t *tunnel) Start() error {
 				if err != nil {
 					klog.Infof("unexpected error listening: %v", err)
 					return
-				} else {
-					go func() {
-						err := t.handleConnection(conn)
-						if err != nil {
-							klog.Infof("unexpected error on connection: %v", err)
-						}
-					}()
 				}
+				tcpConn, ok := conn.(*net.TCPConn)
+				if !ok {
+					klog.Errorf("unexpected connection type %T, expected *net.TCPConn", conn)
+					conn.Close() // nolint: errcheck
+					continue
+				}
+				go func() {
+					err := t.handleTCPConnection(tcpConn)
+					if err != nil {
+						klog.Infof("unexpected error on connection: %v", err)
+					}
+				}()
 			}
 		}()
+	} else {
+		return fmt.Errorf("unsupported protocol %s", t.protocol)
 	}
 	return nil
 }
@@ -175,23 +182,37 @@ func (t *tunnel) Stop() error {
 	return nil
 }
 
-func (t *tunnel) handleConnection(local net.Conn) error {
-	remote, err := net.Dial(t.protocol, net.JoinHostPort(t.remoteIP, t.remotePort))
+func (t *tunnel) handleTCPConnection(local *net.TCPConn) error {
+	tcpAddr, err := net.ResolveTCPAddr(t.protocol, net.JoinHostPort(t.remoteIP, t.remotePort))
+	if err != nil {
+		return fmt.Errorf("can't resolve remote address %q: %v", net.JoinHostPort(t.remoteIP, t.remotePort), err)
+	}
+	remote, err := net.DialTCP(t.protocol, nil, tcpAddr)
 	if err != nil {
 		return fmt.Errorf("can't connect to server %q: %v", net.JoinHostPort(t.remoteIP, t.remotePort), err)
 	}
+
+	// Fully close both connections on return.
 	defer remote.Close()
+	defer local.Close()
 
 	wg := &sync.WaitGroup{}
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
 		io.Copy(local, remote) // nolint: errcheck
+		// Half-close the remote to local path.
+		local.CloseWrite() // nolint: errcheck
+		remote.CloseRead() // nolint: errcheck
 	}()
 	go func() {
 		defer wg.Done()
 		io.Copy(remote, local) // nolint: errcheck
+		// Half-close the local to remote path.
+		remote.CloseWrite() // nolint: errcheck
+		local.CloseRead()   // nolint: errcheck
 	}()
+
 	wg.Wait()
 	return nil
 }


### PR DESCRIPTION
This change ensures that tunneled TCP connections propagate shut downs when they occur, allowing the opposite party to be signaled appropriately.

A TCP connection can be "half-closed" when `A` shuts down `A->B` by sending a FIN to `B`, and `B` responds with an ACK. The connection becomes "fully-closed" when the same procedure is followed for the `A<-B` direction. When a TCP connection is half-closed in the `A->B` direction, data may continue to flow in the `A<-B` direction.

This signaling exists as a basic function of the TCP protocol, allowing either party to indicate that they are done sending data, and that their peer can finish up as they please. Data can continue to flow in the opposite direction until they are ready to shut down their side of the connection.

When cloud-provider-kind (`t`) acts as a tunnel for TCP connections between `A` and `B`, we have two connections `A-t` and `t-B`, and four flows:

- `A->t` and `t->B` (representing `A->B`).
- `A<-t` and `t<-B` (representing `A<-B`).

Prior to this change, when `A` shut down `A->t`, the tunnel would not shut down `t->B`, leaving `A-t` half-closed and `B-t` not closed in any way. The same is true for the opposite direction, as well.

After this change, when `A` shuts down `A->t`, cloud-provider-kind immediately shuts down `t->B`. The same is true when `B` shuts down `t<-B`, `A<-t` is immediately shut down. Flow directions are maintained independently from one-another.

Note: this change effectively restricts tunneled connections to only supporting `udp`, `tcp`, `tcp4`, and `tcp6` protocols. As far as I can tell, docker containers will not expose other protocol types (like unix domain sockets).