### PR TITLE
Group dependabot k8s updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,12 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    groups:
+      k8s-deps:
+        patterns:
+          - "*k8s.io*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
When there are k8s dependency updates there are usually a set of them for things like api, apimachinery, cloud-provider, etc. By default these get updated individually, even though they should be taken as a whole. The larger issue is that approving and merging one usually results in rebasing the others, and some indirect dependencies of one update make some of the other updates obsolete.

This results in a lot of unnecessary CI churn. Since these are almost always wanted as the full set, this adds a group configuration to dependabot to update all k8s package dependencies together so we only need to review and test a single update PR.

Also adds configuration for updating the GitHub Actions we use so we get updates for things like actions/setup-go and actions/checkout.