### PR TITLE
Bump go, k8s, and kind versions

### DIFF
--- a/.github/workflows/bats.yml
+++ b/.github/workflows/bats.yml
@@ -11,9 +11,9 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: "1.23"
-  K8S_VERSION: "v1.32.0"
-  KIND_VERSION: "v0.27.0"
+  GO_VERSION: "1.24"
+  K8S_VERSION: "v1.34.0"
+  KIND_VERSION: "v0.30.0"
 
 jobs:
   bats_tests:
@@ -86,4 +86,3 @@ jobs:
         with:
           name: kind-logs-${{ env.JOB_NAME }}-${{ github.run_id }}
           path: ./_artifacts
-         

--- a/.github/workflows/k8s.yml
+++ b/.github/workflows/k8s.yml
@@ -6,8 +6,8 @@ on:
   workflow_dispatch:
 
 env:
-  K8S_VERSION: "v1.32.0"
-  KIND_VERSION: "v0.26.0"
+  K8S_VERSION: "v1.34.0"
+  KIND_VERSION: "v0.30.0"
   KIND_CLUSTER_NAME: "kind-cloud"
 
 jobs:


### PR DESCRIPTION
Updates GHA variables to latest versions of Go, Kubernetes, and kind releases.