### PR TITLE
Update gateway api to v1.4.0

### DIFF
--- a/.github/workflows/gateway.yml
+++ b/.github/workflows/gateway.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   GO_VERSION: "1.24"
-  GATEWAY_VERSION: "v1.4.0-rc.2"
+  GATEWAY_VERSION: "v1.4.0"
   K8S_VERSION: "v1.34.0"
   KIND_VERSION: "v0.30.0"
   KIND_CLUSTER_NAME: "kind-cloud"

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	k8s.io/controller-manager v0.34.1
 	k8s.io/klog/v2 v2.130.1
 	k8s.io/utils v0.0.0-20250820121507-0af2bda4dd1d
-	sigs.k8s.io/gateway-api v1.4.0-rc.2
+	sigs.k8s.io/gateway-api v1.4.0
 	sigs.k8s.io/kind v0.30.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -258,8 +258,8 @@ k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 h1:Y3gxNAuB0OBLImH611+UDZ
 k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912/go.mod h1:kdmbQkyfwUagLfXIad1y2TdrjPFWp2Q89B3qkRwf/pQ=
 k8s.io/utils v0.0.0-20250820121507-0af2bda4dd1d h1:wAhiDyZ4Tdtt7e46e9M5ZSAJ/MnPGPs+Ki1gHw4w1R0=
 k8s.io/utils v0.0.0-20250820121507-0af2bda4dd1d/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
-sigs.k8s.io/gateway-api v1.4.0-rc.2 h1:1JVw4/b7ug+3AgWDQDSPAnovePYBmSiZ1H1muzgQv8s=
-sigs.k8s.io/gateway-api v1.4.0-rc.2/go.mod h1:AR5RSqciWP98OPckEjOjh2XJhAe2Na4LHyXD2FUY7Qk=
+sigs.k8s.io/gateway-api v1.4.0 h1:ZwlNM6zOHq0h3WUX2gfByPs2yAEsy/EenYJB78jpQfQ=
+sigs.k8s.io/gateway-api v1.4.0/go.mod h1:AR5RSqciWP98OPckEjOjh2XJhAe2Na4LHyXD2FUY7Qk=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/kind v0.30.0 h1:2Xi1KFEfSMm0XDcvKnUt15ZfgRPCT0OnCBbpgh8DztY=

--- a/pkg/gateway/crds/experimental/gateway.networking.k8s.io_backendtlspolicies.yaml
+++ b/pkg/gateway/crds/experimental/gateway.networking.k8s.io_backendtlspolicies.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.4.0-rc.2
+    gateway.networking.k8s.io/bundle-version: v1.4.0
     gateway.networking.k8s.io/channel: experimental
   labels:
     gateway.networking.k8s.io/policy: Direct

--- a/pkg/gateway/crds/experimental/gateway.networking.k8s.io_gatewayclasses.yaml
+++ b/pkg/gateway/crds/experimental/gateway.networking.k8s.io_gatewayclasses.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.4.0-rc.2
+    gateway.networking.k8s.io/bundle-version: v1.4.0
     gateway.networking.k8s.io/channel: experimental
   name: gatewayclasses.gateway.networking.k8s.io
 spec:

--- a/pkg/gateway/crds/experimental/gateway.networking.k8s.io_gateways.yaml
+++ b/pkg/gateway/crds/experimental/gateway.networking.k8s.io_gateways.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.4.0-rc.2
+    gateway.networking.k8s.io/bundle-version: v1.4.0
     gateway.networking.k8s.io/channel: experimental
   name: gateways.gateway.networking.k8s.io
 spec:

--- a/pkg/gateway/crds/experimental/gateway.networking.k8s.io_grpcroutes.yaml
+++ b/pkg/gateway/crds/experimental/gateway.networking.k8s.io_grpcroutes.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.4.0-rc.2
+    gateway.networking.k8s.io/bundle-version: v1.4.0
     gateway.networking.k8s.io/channel: experimental
   name: grpcroutes.gateway.networking.k8s.io
 spec:

--- a/pkg/gateway/crds/experimental/gateway.networking.k8s.io_httproutes.yaml
+++ b/pkg/gateway/crds/experimental/gateway.networking.k8s.io_httproutes.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.4.0-rc.2
+    gateway.networking.k8s.io/bundle-version: v1.4.0
     gateway.networking.k8s.io/channel: experimental
   name: httproutes.gateway.networking.k8s.io
 spec:

--- a/pkg/gateway/crds/experimental/gateway.networking.k8s.io_referencegrants.yaml
+++ b/pkg/gateway/crds/experimental/gateway.networking.k8s.io_referencegrants.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.4.0-rc.2
+    gateway.networking.k8s.io/bundle-version: v1.4.0
     gateway.networking.k8s.io/channel: experimental
   name: referencegrants.gateway.networking.k8s.io
 spec:

--- a/pkg/gateway/crds/experimental/gateway.networking.k8s.io_tcproutes.yaml
+++ b/pkg/gateway/crds/experimental/gateway.networking.k8s.io_tcproutes.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.4.0-rc.2
+    gateway.networking.k8s.io/bundle-version: v1.4.0
     gateway.networking.k8s.io/channel: experimental
   name: tcproutes.gateway.networking.k8s.io
 spec:

--- a/pkg/gateway/crds/experimental/gateway.networking.k8s.io_tlsroutes.yaml
+++ b/pkg/gateway/crds/experimental/gateway.networking.k8s.io_tlsroutes.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.4.0-rc.2
+    gateway.networking.k8s.io/bundle-version: v1.4.0
     gateway.networking.k8s.io/channel: experimental
   name: tlsroutes.gateway.networking.k8s.io
 spec:

--- a/pkg/gateway/crds/experimental/gateway.networking.k8s.io_udproutes.yaml
+++ b/pkg/gateway/crds/experimental/gateway.networking.k8s.io_udproutes.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.4.0-rc.2
+    gateway.networking.k8s.io/bundle-version: v1.4.0
     gateway.networking.k8s.io/channel: experimental
   name: udproutes.gateway.networking.k8s.io
 spec:

--- a/pkg/gateway/crds/experimental/gateway.networking.x-k8s.io_xbackendtrafficpolicies.yaml
+++ b/pkg/gateway/crds/experimental/gateway.networking.x-k8s.io_xbackendtrafficpolicies.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.4.0-rc.2
+    gateway.networking.k8s.io/bundle-version: v1.4.0
     gateway.networking.k8s.io/channel: experimental
   labels:
     gateway.networking.k8s.io/policy: Direct

--- a/pkg/gateway/crds/experimental/gateway.networking.x-k8s.io_xlistenersets.yaml
+++ b/pkg/gateway/crds/experimental/gateway.networking.x-k8s.io_xlistenersets.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.4.0-rc.2
+    gateway.networking.k8s.io/bundle-version: v1.4.0
     gateway.networking.k8s.io/channel: experimental
   name: xlistenersets.gateway.networking.x-k8s.io
 spec:

--- a/pkg/gateway/crds/experimental/gateway.networking.x-k8s.io_xmeshes.yaml
+++ b/pkg/gateway/crds/experimental/gateway.networking.x-k8s.io_xmeshes.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.4.0-rc.2
+    gateway.networking.k8s.io/bundle-version: v1.4.0
     gateway.networking.k8s.io/channel: experimental
   name: xmeshes.gateway.networking.x-k8s.io
 spec:

--- a/pkg/gateway/crds/standard/gateway.networking.k8s.io_backendtlspolicies.yaml
+++ b/pkg/gateway/crds/standard/gateway.networking.k8s.io_backendtlspolicies.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.4.0-rc.2
+    gateway.networking.k8s.io/bundle-version: v1.4.0
     gateway.networking.k8s.io/channel: standard
   labels:
     gateway.networking.k8s.io/policy: Direct

--- a/pkg/gateway/crds/standard/gateway.networking.k8s.io_gatewayclasses.yaml
+++ b/pkg/gateway/crds/standard/gateway.networking.k8s.io_gatewayclasses.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.4.0-rc.2
+    gateway.networking.k8s.io/bundle-version: v1.4.0
     gateway.networking.k8s.io/channel: standard
   name: gatewayclasses.gateway.networking.k8s.io
 spec:

--- a/pkg/gateway/crds/standard/gateway.networking.k8s.io_gateways.yaml
+++ b/pkg/gateway/crds/standard/gateway.networking.k8s.io_gateways.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.4.0-rc.2
+    gateway.networking.k8s.io/bundle-version: v1.4.0
     gateway.networking.k8s.io/channel: standard
   name: gateways.gateway.networking.k8s.io
 spec:

--- a/pkg/gateway/crds/standard/gateway.networking.k8s.io_grpcroutes.yaml
+++ b/pkg/gateway/crds/standard/gateway.networking.k8s.io_grpcroutes.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.4.0-rc.2
+    gateway.networking.k8s.io/bundle-version: v1.4.0
     gateway.networking.k8s.io/channel: standard
   name: grpcroutes.gateway.networking.k8s.io
 spec:

--- a/pkg/gateway/crds/standard/gateway.networking.k8s.io_httproutes.yaml
+++ b/pkg/gateway/crds/standard/gateway.networking.k8s.io_httproutes.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.4.0-rc.2
+    gateway.networking.k8s.io/bundle-version: v1.4.0
     gateway.networking.k8s.io/channel: standard
   name: httproutes.gateway.networking.k8s.io
 spec:

--- a/pkg/gateway/crds/standard/gateway.networking.k8s.io_referencegrants.yaml
+++ b/pkg/gateway/crds/standard/gateway.networking.k8s.io_referencegrants.yaml
@@ -3,7 +3,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: https://github.com/kubernetes-sigs/gateway-api/pull/3328
-    gateway.networking.k8s.io/bundle-version: v1.4.0-rc.2
+    gateway.networking.k8s.io/bundle-version: v1.4.0
     gateway.networking.k8s.io/channel: standard
   name: referencegrants.gateway.networking.k8s.io
 spec:


### PR DESCRIPTION
Updates all go modules using `go get -u` and `go mod tidy`.

Updates to latest CRDs using the `hack/download-gateway-crds.sh` script

Updates GitHub workflow to use the v1.4.0 version.