### PR TITLE
don't set --provider=aws

### DIFF
--- a/hack/ci/e2e.sh
+++ b/hack/ci/e2e.sh
@@ -196,7 +196,7 @@ run_tests() {
   # use aws provider to enable cloud-provider tests, aws is just a nullprovider
   # without any custom logic
   ./hack/ginkgo-e2e.sh \
-    '--provider=aws' "--num-nodes=${NUM_NODES}" \
+    "--num-nodes=${NUM_NODES}" \
     "--ginkgo.focus=${FOCUS}" "--ginkgo.skip=${SKIP}" \
     "--report-dir=${ARTIFACTS}" '--disable-log-dump=true' &
   GINKGO_PID=$!


### PR DESCRIPTION
fixes #303 
/hold
should compare the set of tests run in CI jobs