### PR TITLE
Move Gateway API section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,17 @@ Or using `compose.yaml` file:
 NET_MODE=kind docker compose up -d
 ```
 
+## Gateway API support (Alpha)
+
+This provider has alpha support for the [Gateway API](https://gateway-api.sigs.k8s.io/).
+It implements the `Gateway` and `HTTPRoute` functionalities.
+
+You can enable the Gateway API controllerby selecting the Gateway API release channel (standard/experimental):
+
+```sh
+cloud-provider-kind --gateway-channel standard
+```
+
 ## How to use it
 
 Run a KIND cluster:
@@ -102,17 +113,6 @@ kubectl cluster-info --context kind-kind
 
 Have a question, bug, or feature request? Let us know! https://kind.sigs.k8s.io/#community 🙂
 
-```
-
-## Gateway API support (Alpha)
-
-This provider has alpha support for the [Gateway API](https://gateway-api.sigs.k8s.io/).
-It implements the `Gateway` and `HTTPRoute` functionalities.
-
-You can enable the Gateway API controllerby selecting the Gateway API release channel (standard/experimental):
-
-```sh
-cloud-provider-kind --gateway-channel standard
 ```
 
 ### Allowing load balancers access to control plane nodes


### PR DESCRIPTION
The Gateway API support section was added inside the "How to use it" section of the README, disrupting the flow and making it look like things like "Running the provider" were subsections of Gateway API rather than initial setup instructions.

This moves the Gateway API support section just prior to "How to use it" to keep the flow of the setup instructions.