### PR TITLE
Add default labels for dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,8 +13,14 @@ updates:
       k8s-deps:
         patterns:
           - "*k8s.io*"
+    labels:
+      - "area/dependency"
+      - "ok-to-test"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    labels:
+      - "area/dependency"
+      - "ok-to-test"


### PR DESCRIPTION
This adds `ok-to-test` and `area/depenency` labels to the PRs opened for dependabot updates, primarily to make sure tests are automatically run.