### PR TITLE
Group envoy dependencies for updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,9 @@ updates:
       k8s-deps:
         patterns:
           - "*k8s.io*"
+      envoy-deps:
+        patterns:
+          - "*envoyproxy*"
     labels:
       - "area/dependency"
       - "ok-to-test"


### PR DESCRIPTION
This groups any envoy dependencies in Dependabot updates so they are combined into a single PR. This avoids wasted CI resources and redundant PRs we've seen with each separate envoy dependency triggering its own update that then just needs to be closed once one or the other gets merged.

See #319 and #320 for an example.