### PR TITLE
Correct filepath/path for embed.FS on Windows

### DIFF
--- a/pkg/gateway/crd_manager.go
+++ b/pkg/gateway/crd_manager.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"path/filepath"
+	"path"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -59,7 +59,8 @@ func (m *CRDManager) InstallCRDs(ctx context.Context, channelDir config.GatewayR
 		Resource: crdResource,
 	}
 
-	targetDir := filepath.Join(crdsDir, string(channelDir))
+	// embed.FS always uses Unix path names
+	targetDir := path.Join(crdsDir, string(channelDir))
 
 	klog.Infof("Walking embedded directory for channel %q: %s", channelDir, targetDir)
 	err := fs.WalkDir(crdFS, targetDir, func(path string, d fs.DirEntry, err error) error {
@@ -124,7 +125,6 @@ func (m *CRDManager) InstallCRDs(ctx context.Context, channelDir config.GatewayR
 		}
 		return nil
 	})
-
 	if err != nil {
 		return fmt.Errorf("error processing embedded CRDs from %s: %w", targetDir, err)
 	}


### PR DESCRIPTION
Surprisingly, even on Windows, `embed.FS` uses unix-style paths.  This switches the embedded path logic for finding CRDs to work on Windows.  Without this, you get the following error:

```
E1208 13:53:59.568349    7968 controller.go:294] "Failed to install Gateway API CRDs" err="error processing embedded CRDs from crds\\\\standard: error walking embedded fs at \\"crds\\\\\\\\standard\\": open crds\\\\standard: file does not exist" cluster="kind"
```

Which, in turn, prevents the cloud-provider-kind from starting up and assigning IPs for LoadBalancer services.