### PR TITLE
dependabot: Add settings for Dockerfile updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,3 +27,12 @@ updates:
     labels:
       - "area/dependency"
       - "ok-to-test"
+
+  - package-ecosystem: "docker"
+    directories:
+      - "**/*"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "area/dependency"
+      - "ok-to-test"


### PR DESCRIPTION
Adds the configuration necessary for Dependabot to check and propose updates for things used in the Dockerfile (i.e. the base Go image).