### PR TITLE
Update README for Gateway API support clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,15 +82,17 @@ Or using `compose.yaml` file:
 NET_MODE=kind docker compose up -d
 ```
 
-## Gateway API support (Alpha)
+## Gateway API support
 
-This provider has alpha support for the [Gateway API](https://gateway-api.sigs.k8s.io/).
-It implements the `Gateway` and `HTTPRoute` functionalities.
+This provider has support for the [Gateway API](https://gateway-api.sigs.k8s.io/).
+It implements the `Gateway` and `HTTPRoute` functionalities and passes the community conformance tests.
 
-You can enable the Gateway API controllerby selecting the Gateway API release channel (standard/experimental):
+The Gateway API controller is enabled by default using the standard channel,
+but you can select the Gateway API release channel (standard/experimental) or just disable the feature completely
+using the flag `gateway-channel`:
 
 ```sh
-cloud-provider-kind --gateway-channel standard
+cloud-provider-kind --gateway-channel standard|experimental|disabled
 ```
 
 ## How to use it


### PR DESCRIPTION
Clarified Gateway API support details and usage instructions.

Gateway API is enabled by default and passes all conformance tests, it is a gateway implementation that works on kind clusters, so that is the context of this functionality