### PR TITLE
fix: disable Envoy healthy panic threshold

### DIFF
--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -16,6 +16,7 @@ import (
 	endpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	listenerv3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	typev3 "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	envoyproxytypes "github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	cachev3 "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
 	resourcev3 "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
@@ -655,6 +656,11 @@ func (c *Controller) translateBackendRefToCluster(defaultNamespace string, backe
 	cluster := &clusterv3.Cluster{
 		Name:           clusterName,
 		ConnectTimeout: durationpb.New(5 * time.Second),
+		CommonLbConfig: &clusterv3.Cluster_CommonLbConfig{
+			HealthyPanicThreshold: &typev3.Percent{
+				Value: 0,
+			},
+		},
 	}
 
 	if service.Spec.ClusterIP == corev1.ClusterIPNone {

--- a/pkg/loadbalancer/proxy.go
+++ b/pkg/loadbalancer/proxy.go
@@ -152,6 +152,9 @@ resources:
   name: cluster_{{$index}}
   connect_timeout: 5s
   type: STATIC
+  common_lb_config:
+    healthy_panic_threshold:
+      value: 0
   {{- if eq $.SessionAffinity "ClientIP"}}
   lb_policy: RING_HASH
   {{- else}}

--- a/pkg/loadbalancer/proxy_test.go
+++ b/pkg/loadbalancer/proxy_test.go
@@ -298,8 +298,8 @@ func Test_generateConfig(t *testing.T) {
 					},
 				},
 				SourceRanges: []sourceRange{
-					{ Prefix: "10.0.0.0", Length: 8},
-					{ Prefix: "192.168.0.0", Length: 16},
+					{Prefix: "10.0.0.0", Length: 8},
+					{Prefix: "192.168.0.0", Length: 16},
 				},
 			},
 		},
@@ -343,6 +343,9 @@ func Test_proxyConfig(t *testing.T) {
 				  name: cluster_IPv4_443
 				  connect_timeout: 5s
 				  type: STATIC
+				  common_lb_config:
+				    healthy_panic_threshold:
+				      value: 0
 				  lb_policy: RANDOM
 				  health_checks:
 				  - timeout: 5s
@@ -380,6 +383,9 @@ func Test_proxyConfig(t *testing.T) {
 				  name: cluster_IPv4_80
 				  connect_timeout: 5s
 				  type: STATIC
+				  common_lb_config:
+				    healthy_panic_threshold:
+				      value: 0
 				  lb_policy: RANDOM
 				  health_checks:
 				  - timeout: 5s
@@ -490,6 +496,9 @@ func Test_proxyConfig(t *testing.T) {
 				  name: cluster_IPv4_80
 				  connect_timeout: 5s
 				  type: STATIC
+				  common_lb_config:
+				    healthy_panic_threshold:
+				      value: 0
 				  lb_policy: RING_HASH
 				  health_checks:
 				  - timeout: 5s
@@ -574,8 +583,8 @@ func Test_proxyConfig(t *testing.T) {
 					},
 				},
 				SourceRanges: []sourceRange{
-					{ Prefix: "10.0.0.0", Length: 8},
-					{ Prefix: "192.168.0.0", Length: 16},
+					{Prefix: "10.0.0.0", Length: 8},
+					{Prefix: "192.168.0.0", Length: 16},
 				},
 			},
 			wantConfig: `


### PR DESCRIPTION
By default, Envoy enables a "healthy panic threshold" of 50%. This causes Envoy to enter "panic mode" and route traffic to all upstream hosts—including unhealthy ones—if the percentage of healthy hosts drops below this threshold.

In a Kubernetes environment, this behavior defeats the purpose of Readiness probes and the Service controller. Kubernetes explicitly manages endpoint health; if a Pod is not ready, it is removed from the EndpointSlice/Endpoints API. The Cloud Provider LoadBalancer is expected to strictly respect this state.

This commit sets the `healthy_panic_threshold` to 0% for both Gateway API (xDS) and LoadBalancer (static) configurations. This ensures the LoadBalancer behaves deterministically and "fails closed" (returns 503s) rather than "failing open" (sending traffic to broken Pods) when the cluster is in a degraded state.

Fixes: https://github.com/kubernetes-sigs/cloud-provider-kind/issues/359