### PR TITLE
feat: added version command

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -9,3 +9,5 @@ builds:
     goarch:
       - amd64
       - arm64
+    ldflags:
+      - -s -w -X sigs.k8s.io/cloud-provider-kind/cmd.version={{.Version}}

--- a/cmd/app.go
+++ b/cmd/app.go
@@ -28,6 +28,7 @@ var (
 	enableLBPortMapping  bool
 	gatewayChannel       string
 	enableDefaultIngress bool
+	version              string
 )
 
 func Main() {
@@ -57,6 +58,7 @@ func NewCommand() *cobra.Command {
 
 
 	cmd.AddCommand(newListImagesCommand())
+	cmd.AddCommand(newVersionCommand())
 
 	return cmd
 }
@@ -67,6 +69,16 @@ func newListImagesCommand() *cobra.Command {
 		Short: "list images used by cloud-provider-kind",
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Println(config.DefaultConfig.ProxyImage)
+		},
+	}
+}
+
+func newVersionCommand() *cobra.Command {
+	return &cobra.Command{
+		Use: "version",
+		Short: "print the cloud-provider-kind version",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println("cloud-provider-kind", version)
 		},
 	}
 }


### PR DESCRIPTION
## Implementation
Following what discussed in issue: #363 I've added a new cobra command to display the current version of the application.
The command prints the value of the `version`  variable defined in the `app.go` file. The value of the variable is injected at build time by `goreleaser` with the ldflag `-X` defined in `.goreleaser.yaml`

## Produced ouput
### using `help` or `--help`
```bash
$ cloud-provider-kind --help
cloud-provider-kind is a cloud provider for kind clusters

Usage:
  cloud-provider-kind [flags]
  cloud-provider-kind [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  help        Help about any command
  list-images list images used by cloud-provider-kind
  version     print the cloud-provider-kind version

Flags:
      --enable-default-ingress   enable default ingress for the cloud provider kind ingress (default true)
      --enable-lb-port-mapping   enable port-mapping on the load balancer ports
      --enable-log-dumping       store logs to a temporal directory or to the directory specified using the logs-dir flag
      --gateway-channel string   define the gateway API release channel to be used (standard, experimental, disabled), by default is standard (default "standard")
  -h, --help                     help for cloud-provider-kind
      --logs-dir string          store logs to the specified directory
  -v, --verbosity int            Verbosity level (default 2)

Use "cloud-provider-kind [command] --help" for more information about a command.
```

### After building a snapshot with `goreleaser`

```bash
$ cloud-provider-kind version
cloud-provider-kind 0.10.0-SNAPSHOT-fbced46e
```

### After building a release with `goreleaser`

```bash
$ cloud-provider-kind version
cloud-provider-kind 0.10.0
```