### PR TITLE
Fix Gateway CRD manager choking on kustomization.yaml

### DIFF
--- a/pkg/gateway/crd_manager.go
+++ b/pkg/gateway/crd_manager.go
@@ -79,6 +79,11 @@ func (m *CRDManager) InstallCRDs(ctx context.Context, channelDir config.GatewayR
 			return nil // Continue walking
 		}
 
+		// Skip the kustomize files
+		if strings.HasSuffix(path, "kustomization.yaml") {
+			return nil
+		}
+
 		// Process only YAML files
 		if !strings.HasSuffix(path, ".yaml") && !strings.HasSuffix(path, ".yml") {
 			klog.V(4).Infof("Skipping non-yaml file: %s", path)

--- a/pkg/gateway/crd_manager_test.go
+++ b/pkg/gateway/crd_manager_test.go
@@ -1,0 +1,42 @@
+package gateway
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic/fake"
+	"sigs.k8s.io/cloud-provider-kind/pkg/config"
+)
+
+func TestYAMLFilesApply(t *testing.T) {
+	tests := []struct {
+		name string
+		channel config.GatewayReleaseChannel
+	}{
+		{
+		name: "Stable release channel",
+		channel: config.Standard,
+		},
+
+		{
+			name: "Experimental release channel",
+			channel: config.Experimental,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manager := CRDManager {
+				dynamicClient: fake.NewSimpleDynamicClient(runtime.NewScheme()),
+
+			}
+
+			if err := manager.InstallCRDs(t.Context(), tt.channel); err != nil {
+				t.Fatalf("couldn't install CRDs: %v", err)
+
+			}
+		})
+
+	}
+}
+


### PR DESCRIPTION
When using the Experimental gateway channel, the directory contains a `kustomization.yaml` that the crd manager attempts to load as a k8s object, which fails. 

This PR adds a one-off exception for that file (the only one present in [the directory](https://github.com/kubernetes-sigs/cloud-provider-kind/tree/e6c33ec3e6867a491a3dfee4a55ff293e54beba0/pkg/gateway/crds/experimental)) and adds tests for good measure.