### PR TITLE
Make KIND_EXPERIMENTAL_PROVIDER detection consistent

### DIFF
--- a/cmd/app.go
+++ b/cmd/app.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"sigs.k8s.io/cloud-provider-kind/pkg/config"
+	"sigs.k8s.io/cloud-provider-kind/pkg/container"
 	"sigs.k8s.io/cloud-provider-kind/pkg/controller"
 	"sigs.k8s.io/kind/pkg/cluster"
 	kindcmd "sigs.k8s.io/kind/pkg/cmd"
@@ -164,9 +165,14 @@ func runE(cmd *cobra.Command, args []string) error {
 	config.DefaultConfig.ControlPlaneConnectivity = config.Portmap
 
 	// initialize kind provider
-	option, err := cluster.DetectNodeProvider()
-	if err != nil {
-		return fmt.Errorf("can not detect cluster provider: %v", err)
+	var option cluster.ProviderOption
+	switch p := container.Runtime(); p {
+	case "podman":
+		option = cluster.ProviderWithPodman()
+	case "nerdctl", "finch", "nerdctl.lima":
+		option = cluster.ProviderWithNerdctl(p)
+	default:
+		option = cluster.ProviderWithDocker()
 	}
 	kindProvider := cluster.NewProvider(
 		option,

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -49,6 +49,11 @@ func nerdctlIsAvailable() bool {
 	return strings.HasPrefix(lines[0], "nerdctl version")
 }
 
+// Runtime returns the detected container runtime name.
+func Runtime() string {
+	return containerRuntime
+}
+
 func init() {
 	// allow to override the container provider as we do in KIND
 	if p := os.Getenv("KIND_EXPERIMENTAL_PROVIDER"); p != "" {


### PR DESCRIPTION
We could run into issues in some environments due to different ways we were detecting the local runtime.

For load balancer container operations we would explicitly set the value if KIND_EXPERIMENTAL_PROVIDER was set. But for other operations we would just autodetect. So when docker and podman were present, even if KIND_EXPERIMENTAL_PROVIDER was set to podman, it would find docker first and use that.

This refactors provider selection logic to only be performed once. The name of the provider is already being [determined (correctly) on init](https://github.com/kubernetes-sigs/cloud-provider-kind/blob/c2bc0a61c4172d498a8deee207ce620689eca40e/pkg/container/container.go#L54). So later when we are determining which provider to initialize, rather than doing that detection again, this stores off the value during init so we can just access it when needed and use it to initialize the correct provider.

Closes: #382