### PR TITLE
docs: add dedicated installation by binary released

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -2,6 +2,7 @@
 
   - [Installation with go ](user/install/install_go.md)
   - [Running with docker](user/install/install_docker.md)
+  - [Installation downloading the binary released](user/install/install_downloading_binary.md)
 - Ingress
   - [Setting up Ingress](user/ingress/ingress.md)
 - Gateway API 

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -1,6 +1,7 @@
 - Install 
 
   - [Installation with go ](user/install/install_go.md)
+  - [Installation with a package manager](user/install/install_package_manager.md)
   - [Running with docker](user/install/install_docker.md)
   - [Installation downloading the binary released](user/install/install_downloading_binary.md)
 - Ingress

--- a/docs/user/install/install_downloading_binary.md
+++ b/docs/user/install/install_downloading_binary.md
@@ -1,0 +1,4 @@
+### Installing downloading the binary released
+
+You can download your desired [binary released](https://github.com/kubernetes-sigs/cloud-provider-kind/releases).
+Then installed it.

--- a/docs/user/install/install_go.md
+++ b/docs/user/install/install_go.md
@@ -12,16 +12,3 @@ can make it available elsewhere if appropriate:
 ```sh
 sudo install ~/go/bin/cloud-provider-kind /usr/local/bin
 ```
-
-### Installing With A Package Manager
-
-The cloud-provider-kind community has enabled installation via the following package managers.
-
-> [!NOTE]
-> The following are community supported efforts. The `cloud-provider-kind` maintainers are not involved in the creation of these packages, and the upstream community makes no claims on the validity, safety, or content of them.
-
-On macOS via Homebrew:
-
-```sh
-brew install cloud-provider-kind
-```

--- a/docs/user/install/install_package_manager.md
+++ b/docs/user/install/install_package_manager.md
@@ -1,0 +1,12 @@
+### Installing With A Package Manager
+
+The cloud-provider-kind community has enabled installation via the following package managers.
+
+> [!NOTE]
+> The following are community supported efforts. The `cloud-provider-kind` maintainers are not involved in the creation of these packages, and the upstream community makes no claims on the validity, safety, or content of them.
+
+On macOS via Homebrew:
+
+```sh
+brew install cloud-provider-kind
+```


### PR DESCRIPTION
# Description
* add dedicated installation by binary released
  * Reason: 
    *  it's possible
    * it's even specified [in Kind documentation](https://kind.sigs.k8s.io/docs/user/loadbalancer/)
* refactor the package manager installation to dedicated file
