### PR TITLE
Refine runtime detection logic

### DIFF
--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -15,38 +15,27 @@ import (
 // TODO we can do it as in KIND
 var containerRuntime = "docker"
 
-// dockerIsAvailable checks if docker is available in the system
+// dockerIsAvailable checks if docker is available and the daemon is running
 func dockerIsAvailable() bool {
-	cmd := kindexec.Command("docker", "-v")
-	lines, err := kindexec.OutputLines(cmd)
-	if err != nil || len(lines) != 1 {
-		return false
-	}
-	return strings.HasPrefix(lines[0], "Docker version")
+	cmd := kindexec.Command("docker", "info")
+	_, err := kindexec.OutputLines(cmd)
+	return err == nil
 }
 
 func podmanIsAvailable() bool {
-	cmd := kindexec.Command("podman", "-v")
-	lines, err := kindexec.OutputLines(cmd)
-	if err != nil || len(lines) != 1 {
-		return false
-	}
-	return strings.HasPrefix(lines[0], "podman version")
+	cmd := kindexec.Command("podman", "info")
+	_, err := kindexec.OutputLines(cmd)
+	return err == nil
 }
 
 func nerdctlIsAvailable() bool {
-	cmd := kindexec.Command("nerdctl", "-v")
-	lines, err := kindexec.OutputLines(cmd)
-	if err != nil || len(lines) != 1 {
-		// check finch
-		cmd = kindexec.Command("finch", "-v")
-		lines, err = kindexec.OutputLines(cmd)
-		if err != nil || len(lines) != 1 {
-			return false
-		}
-		return strings.HasPrefix(lines[0], "finch version")
+	cmd := kindexec.Command("nerdctl", "info")
+	if _, err := kindexec.OutputLines(cmd); err == nil {
+		return true
 	}
-	return strings.HasPrefix(lines[0], "nerdctl version")
+	cmd = kindexec.Command("finch", "info")
+	_, err := kindexec.OutputLines(cmd)
+	return err == nil
 }
 
 // Runtime returns the detected container runtime name.


### PR DESCRIPTION
We would have occasional issues trying to do things like use `docker` on a `podman` system. We have the `KIND_EXPERIMENTAL_PROVIDER` override, but that's not always obvious to users. It's also common that users have the `docker` CLI installed, but either as an alias for podman, or for other uses.

Our existing logic was to run the "version" command for each runtime client. If the command worked (i.e. the binary was present) then we would assume that was an available runtime.

This updates that logic to actually run a command that would require that runtime to be running - `docker info`, etc. If the binary is present but that given runtime is non-functional then we will not incorrectly assume it can be used for our purposes.

Related to: #404