### PR TITLE
Explicitly set provider runtime

### DIFF
--- a/cmd/app.go
+++ b/cmd/app.go
@@ -165,14 +165,38 @@ func runE(cmd *cobra.Command, args []string) error {
 	config.DefaultConfig.ControlPlaneConnectivity = config.Portmap
 
 	// initialize kind provider
+	// Check KIND_EXPERIMENTAL_PROVIDER directly, as the kind CLI does, so it
+	// takes effect regardless of auto-detection results.
 	var option cluster.ProviderOption
-	switch p := container.Runtime(); p {
-	case "podman":
-		option = cluster.ProviderWithPodman()
-	case "nerdctl", "finch", "nerdctl.lima":
-		option = cluster.ProviderWithNerdctl(p)
-	default:
-		option = cluster.ProviderWithDocker()
+	if p := os.Getenv("KIND_EXPERIMENTAL_PROVIDER"); p != "" {
+		switch p {
+		case "podman":
+			klog.Infof("Using podman provider due to KIND_EXPERIMENTAL_PROVIDER")
+			option = cluster.ProviderWithPodman()
+			container.SetRuntime("podman")
+		case "docker":
+			klog.Infof("Using docker provider due to KIND_EXPERIMENTAL_PROVIDER")
+			option = cluster.ProviderWithDocker()
+			container.SetRuntime("docker")
+		case "nerdctl", "finch", "nerdctl.lima":
+			klog.Infof("Using %s provider due to KIND_EXPERIMENTAL_PROVIDER", p)
+			option = cluster.ProviderWithNerdctl(p)
+			container.SetRuntime(p)
+		default:
+			klog.Warningf("Ignoring unknown KIND_EXPERIMENTAL_PROVIDER value %q", p)
+		}
+	}
+	if option == nil {
+		p := container.DetectRuntime()
+		container.SetRuntime(p)
+		switch p {
+		case "podman":
+			option = cluster.ProviderWithPodman()
+		case "nerdctl", "finch", "nerdctl.lima":
+			option = cluster.ProviderWithNerdctl(p)
+		default:
+			option = cluster.ProviderWithDocker()
+		}
 	}
 	kindProvider := cluster.NewProvider(
 		option,

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -54,28 +54,28 @@ func Runtime() string {
 	return containerRuntime
 }
 
-func init() {
-	// allow to override the container provider as we do in KIND
-	if p := os.Getenv("KIND_EXPERIMENTAL_PROVIDER"); p != "" {
-		containerRuntime = p
-		return
-	}
+// SetRuntime overrides the auto-detected container runtime.
+func SetRuntime(name string) {
+	containerRuntime = name
+}
 
+// DetectRuntime probes the system for an available container runtime.
+func DetectRuntime() string {
 	if dockerIsAvailable() {
-		return
+		return "docker"
 	}
 	if podmanIsAvailable() {
-		containerRuntime = "podman"
-		return
+		return "podman"
 	}
 	if nerdctlIsAvailable() {
-		containerRuntime = "nerdctl"
 		if _, err := exec.LookPath("nerdctl"); err != nil {
 			if _, err := exec.LookPath("finch"); err == nil {
-				containerRuntime = "finch"
+				return "finch"
 			}
 		}
+		return "nerdctl"
 	}
+	return "docker"
 }
 
 func Logs(name string, w io.Writer) error {


### PR DESCRIPTION
Improves logic around which runtime to use, making sure to always account for KIND_EXPERIMENTAL_PROVIDER environment variable setting.

Related to: #404