### PR TITLE
cloudbuild: pin gcb-docker-gcloud image (v20260205-38cfa9523f)

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -3,7 +3,7 @@ options:
   substitution_option: ALLOW_LOOSE
   machineType: E2_HIGHCPU_32
 steps:
-- name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20240718-5ef92b5c36
+- name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud@sha256:ff388e0dc16351e96f8464e2e185b74a7578a5ccb7a112cf3393468e59e6e2d2 # v20260205-38cfa9523f
   entrypoint: make
   env:
   - REGISTRY=us-central1-docker.pkg.dev/k8s-staging-images/cloud-provider-kind


### PR DESCRIPTION
Older gcr.io/k8s-staging-test-infra/gcb-docker-gcloud tags were removed under the staging registry retention policy, which breaks Cloud Build when the manifest is no longer available (manifest unknown).

This change replaces the GC’d tag v20240718-5ef92b5c36 with a digest pin and keeps the human-readable tag in a comment (v20260205-38cfa9523f, digest sha256:ff388e0dc16351e96f8464e2e185b74a7578a5ccb7a112cf3393468e59e6e2d2) so image push jobs stay reliable if tags are swept again.

Related: kubernetes/kubernetes#138936