### PR TITLE
Fix typo: succesfully -> successfully in connection log

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -166,7 +166,7 @@ func (c *Controller) getRestConfig(ctx context.Context, cluster string) (*rest.C
 			logger.Error(err, "Failed to connect to any address", "addresses", addresses)
 			time.Sleep(time.Second * time.Duration(i))
 		} else {
-			logger.Info("Connected succesfully", "host", host)
+			logger.Info("Connected successfully", "host", host)
 			break
 		}
 	}


### PR DESCRIPTION
Fixes typo in the controller's successful-connection log message.