### PR TITLE
fix container publish args duplicates - container fails to deploy

### DIFF
--- a/examples/gateway_http_multi_listener.yaml
+++ b/examples/gateway_http_multi_listener.yaml
@@ -1,0 +1,73 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: multi-listener-gateway
+spec:
+  gatewayClassName: cloud-provider-kind
+  listeners:
+  - protocol: HTTP
+    port: 80
+    hostname: "*.multi-listener.test"
+    name: wildcard
+    allowedRoutes:
+      namespaces:
+        from: All
+  - protocol: HTTP
+    port: 80
+    hostname: multi-listener.test
+    name: root
+    allowedRoutes:
+      namespaces:
+        from: All
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: multi-listener-route
+spec:
+  parentRefs:
+  - name: multi-listener-gateway
+  hostnames:
+    - route.multi-listener.test
+  rules:
+  - backendRefs:
+    - name: multi-listener-app-svc
+      port: 8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: multi-listener-app
+spec:
+  selector:
+    matchLabels:
+      app: MultiListenerApp
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: MultiListenerApp
+    spec:
+      containers:
+      - name: multi-listener-app
+        image: registry.k8s.io/e2e-test-images/agnhost:2.63.0
+        args:
+          - netexec
+          - --http-port=80
+          - --delay-shutdown=30
+        ports:
+          - name: httpd
+            containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: multi-listener-app-svc
+spec:
+  type: ClusterIP
+  selector:
+    app: MultiListenerApp
+  ports:
+    - name: httpd
+      port: 8080
+      targetPort: 80

--- a/pkg/gateway/envoy.go
+++ b/pkg/gateway/envoy.go
@@ -214,17 +214,27 @@ func createGateway(clusterName string, nameserver string, localAddress string, l
 		// advertised but not functional end-to-end (e.g. some GitHub Actions runners).
 		// For dual-stack or unspecified gateways, publish without an explicit address.
 		// See https://github.com/kubernetes-sigs/cloud-provider-kind/issues/387
+		seen := make(map[string]struct{})
 		for _, listener := range gateway.Spec.Listeners {
 			proto := "tcp"
 			if listener.Protocol == gatewayv1.UDPProtocolType {
 				proto = "udp"
 			}
+
+			var publishArg string
 			if listenAddress != "" {
 				hostPortBinding := net.JoinHostPort(listenAddress, fmt.Sprintf("%d", listener.Port))
-				args = append(args, fmt.Sprintf("--publish=%s:%d/%s", hostPortBinding, listener.Port, proto))
+				publishArg = fmt.Sprintf("--publish=%s:%d/%s", hostPortBinding, listener.Port, proto)
 			} else {
-				args = append(args, fmt.Sprintf("--publish=%d/%s", listener.Port, proto))
+				publishArg = fmt.Sprintf("--publish=%d/%s", listener.Port, proto)
 			}
+
+			if _, exists := seen[publishArg]; exists {
+				continue
+			}
+
+			seen[publishArg] = struct{}{}
+			args = append(args, publishArg)
 		}
 	}
 	args = append(args, "--publish-all")

--- a/tests/setup_suite.bash
+++ b/tests/setup_suite.bash
@@ -15,7 +15,7 @@ function setup_suite {
   kind create cluster --name $CLUSTER_NAME -v7 --wait 1m --retain --config="$BATS_TEST_DIRNAME/kind.yaml"
 
   cd "$BATS_TEST_DIRNAME"/.. && make
-  nohup "$BATS_TEST_DIRNAME"/../bin/cloud-provider-kind -v 2 --gateway-channel=standard --enable-log-dumping --logs-dir "$ARTIFACTS_DIR" > "$ARTIFACTS_DIR"/ccm-kind.log 2>&1 &
+  nohup "$BATS_TEST_DIRNAME"/../bin/cloud-provider-kind -v 2 --gateway-channel=standard --enable-lb-port-mapping --enable-log-dumping --logs-dir "$ARTIFACTS_DIR" > "$ARTIFACTS_DIR"/ccm-kind.log 2>&1 &
   export CCM_PID=$!
 
   # test depend on external connectivity that can be very flaky

--- a/tests/tests.bats
+++ b/tests/tests.bats
@@ -119,6 +119,42 @@
     kubectl delete --ignore-not-found -f "$BATS_TEST_DIRNAME"/../examples/gateway_httproute_simple.yaml
 }
 
+@test "Gateway: Multiple HTTP Listeners on Same Port with enable-lb-port-mapping" {
+    # Reproduces duplicate --publish=80/tcp causing Docker exit status 125.
+    kubectl apply -f "$BATS_TEST_DIRNAME"/../examples/gateway_http_multi_listener.yaml
+
+    # Wait for the backend application pod to be ready
+    kubectl wait --for=condition=ready pods -l app=MultiListenerApp --timeout=60s
+
+    # Retry loop to get the Gateway's external IP address
+    for i in {1..10}
+    do
+        IP=$(kubectl get gateway multi-listener-gateway --output jsonpath='{.status.addresses[0].value}' 2>/dev/null)
+        [[ ! -z "$IP" ]] && break || sleep 1
+    done
+    if [[ -z "$IP" ]]; then
+      echo "Failed to get Gateway IP address"
+      return 1
+    fi
+    echo "Gateway IP: $IP"
+
+    # Verify the gateway container is reachable (if duplicates existed, container creation would have failed)
+    for i in {1..10}
+    do
+        HOSTNAME=$(curl -s --connect-timeout 5 http://${IP}/hostname -H "Host: route.multi-listener.test" || true)
+        [[ ! -z "$HOSTNAME" ]] && break || sleep 1
+    done
+    if [[ -z "$HOSTNAME" ]]; then
+      echo "Failed to get hostname via Gateway"
+      return 1
+    fi
+    echo "Hostname via Gateway: $HOSTNAME"
+
+    # Cleanup
+    kubectl delete --ignore-not-found -f "$BATS_TEST_DIRNAME"/../examples/gateway_http_multi_listener.yaml
+}
+
+
 
 @test "Ingress to Gateway Migration and X-Forwarded-For Header" {
     # Apply the Gateway and HTTPRoute manifests


### PR DESCRIPTION
## Bug: duplicate `--publish=443/tcp` when Gateway has multiple HTTPS listeners on the same port

### Problem

When a `Gateway` defines multiple HTTPS listeners on the same port (`443`) with different hostnames, `cloud-provider-kind` attempts to create the gateway container with duplicate Docker publish arguments:

```text
--publish=443/tcp --publish=443/tcp
````

Docker then fails to create the container with exit status `125`.

This occurs when the Gateway includes both:

```yaml
protocol: HTTPS
port: 443
hostname: "*.birdyleaf.test"
```

and:

```yaml
protocol: HTTPS
port: 443
hostname: birdyleaf.test
```

Since both listeners use the same protocol and port, the generated Docker container should only publish port `443/tcp` once.

### Expected behavior

The gateway container should be created successfully.

For multiple listeners using the same protocol and port, the Docker publish argument should be deduplicated, for example:

```text
--publish=443/tcp
```

### Actual behavior

Container creation fails because Docker receives duplicate publish arguments:

```text
--publish=443/tcp --publish=443/tcp
```

The controller reports:

```text
Error syncing Gateway default/birdyleaf-gateway: failed to ensure gateway container kindccm-gw-15a36518b9b6: failed to create containers kindccm-gw-15a36518b9b6 [...] --publish=443/tcp --publish=443/tcp --publish-all docker.io/envoyproxy/envoy:v1.33.2 [...] exit status 125
```

### Error log

```text
I0520 12:10:19.336014 50788 controller.go:666] Error syncing Gateway default/birdyleaf-gateway: failed to ensure gateway container kindccm-gw-15a36518b9b6: failed to create containers kindccm-gw-15a36518b9b6 [--detach --tty --user=0 --label io.x-k8s.cloud-provider-kind.cluster=kind --label io.x-k8s.cloud-provider-kind.gateway.name=kind/default/birdyleaf-gateway --net kind --dns 10.96.0.10 --init=false --hostname kindccm-gw-15a36518b9b6 --privileged --restart=on-failure --sysctl=net.ipv4.ip_forward=1 --sysctl=net.ipv4.conf.all.rp_filter=0 --sysctl=net.ipv4.ip_unprivileged_port_start=1 --sysctl=net.ipv6.conf.all.disable_ipv6=0 --sysctl=net.ipv6.conf.all.forwarding=1 --publish=443/tcp --publish=443/tcp --publish-all docker.io/envoyproxy/envoy:v1.33.2 bash -c echo -en 'node: cluster: kind/default/birdyleaf-gateway id: kindccm-gw-15a36518b9b6 dynamic_resources: ads_config: api_type: GRPC grpc_services: - envoy_grpc: cluster_name: xds_cluster cds_config: ads: {} lds_config: ads: {} static_resources: clusters: - type: STRICT_DNS typed_extension_protocol_options: envoy.extensions.upstreams.http.v3.HttpProtocolOptions: "@type": type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions explicit_http_config: http2_protocol_options: {} name: xds_cluster load_assignment: cluster_name: xds_cluster endpoints: - lb_endpoints: - endpoint: address: socket_address: address: 172.17.0.1 port_value: 34393 - endpoint: address: socket_address: address: host.docker.internal port_value: 34393 - endpoint: address: socket_address: address: host.lima.internal port_value: 34393 admin: access_log_path: /dev/stdout address: socket_address: address: 0.0.0.0 port_value: 10000 ' > /home/envoy/envoy.yaml && while true; do envoy -c /home/envoy/envoy.yaml && break; sleep 1; done]: exit status 125
```

### Reproduction

Apply a Gateway with two HTTPS listeners on port `443`, one for a wildcard hostname and one for the root hostname.

```yaml
apiVersion: gateway.networking.k8s.io/v1
kind: Gateway
metadata:
  name: birdyleaf-gateway
  namespace: default
  annotations:
    cert-manager.io/cluster-issuer: birdyleaf-local-issuer
spec:
  gatewayClassName: cloud-provider-kind
  addresses:
    - type: IPAddress
      value: 172.18.0.10
  listeners:
    - name: https-wildcard
      protocol: HTTPS
      port: 443
      hostname: "*.birdyleaf.test"
      tls:
        mode: Terminate
        certificateRefs:
          - name: birdyleaf-wildcard-cert
      allowedRoutes:
        namespaces:
          from: All

    - name: https-root
      protocol: HTTPS
      port: 443
      hostname: birdyleaf.test
      tls:
        mode: Terminate
        certificateRefs:
          - name: birdyleaf-root-cert
      allowedRoutes:
        namespaces:
          from: All
```

### Suggested fix

Deduplicate published container ports when generating the Docker container arguments for Gateway listeners.

The publish list should likely be keyed by protocol and port, rather than by listener, so multiple listeners on the same port only produce one Docker publish argument.