### PR TITLE
Allow a static host port number to be specified using `--enable-lb-port-mapping=<port>`

### DIFF
--- a/cmd/app.go
+++ b/cmd/app.go
@@ -26,7 +26,7 @@ var (
 	flagV                int
 	enableLogDump        bool
 	logDumpDir           string
-	enableLBPortMapping  bool
+	enableLBPortMapping  string
 	gatewayChannel       string
 	enableDefaultIngress bool
 	version              string
@@ -53,10 +53,10 @@ func NewCommand() *cobra.Command {
 	cmd.Flags().IntVarP(&flagV, "verbosity", "v", 2, "Verbosity level")
 	cmd.Flags().BoolVar(&enableLogDump, "enable-log-dumping", false, "store logs to a temporal directory or to the directory specified using the logs-dir flag")
 	cmd.Flags().StringVar(&logDumpDir, "logs-dir", "", "store logs to the specified directory")
-	cmd.Flags().BoolVar(&enableLBPortMapping, "enable-lb-port-mapping", false, "enable port-mapping on the load balancer ports")
+	cmd.Flags().StringVar(&enableLBPortMapping, "enable-lb-port-mapping", "", "enable port-mapping on the load balancer ports; optionally specify a static host port after the equals sign (specifying 0 or omitting assigns an ephemeral port)")
+	cmd.Flags().Lookup("enable-lb-port-mapping").NoOptDefVal = "0" // ephemeral
 	cmd.Flags().StringVar(&gatewayChannel, "gateway-channel", "standard", "define the gateway API release channel to be used (standard, experimental, disabled), by default is standard")
 	cmd.Flags().BoolVar(&enableDefaultIngress, "enable-default-ingress", true, "enable default ingress for the cloud provider kind ingress")
-
 
 	cmd.AddCommand(newListImagesCommand())
 	cmd.AddCommand(newVersionCommand())
@@ -167,8 +167,13 @@ func runE(cmd *cobra.Command, args []string) error {
 	}
 
 	// flag overrides autodetection
-	if enableLBPortMapping {
+	if enableLBPortMapping != "" {
+		hostPort, err := strconv.ParseInt(enableLBPortMapping, 10, 32)
+		if err != nil || hostPort < 0 || hostPort > 65535 {
+			return fmt.Errorf("invalid --enable-lb-port-mapping value %q: must be a port number between 0 and 65535", enableLBPortMapping)
+		}
 		config.DefaultConfig.LoadBalancerConnectivity = config.Portmap
+		config.DefaultConfig.LoadBalancerPortMappingHostPort = int32(hostPort)
 	}
 
 	// default control plane connectivity to portmap, it will be

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -34,6 +34,9 @@ type Config struct {
 	// and do userspace proxying from the original port to the portmaps.
 	// If the cloud-provider-kind runs in a container on these platforms only enables portmapping.
 	LoadBalancerConnectivity Connectivity
+	// Host port used when LoadBalancerConnectivity is Portmap.
+	// 0 means the OS assigns an ephemeral port; any other value is used as-is.
+	LoadBalancerPortMappingHostPort int32
 	// Type of connectivity between the cloud-provider-kind and the clusters
 	ControlPlaneConnectivity Connectivity
 	// Gateway API Release channel (default stable)

--- a/pkg/gateway/envoy.go
+++ b/pkg/gateway/envoy.go
@@ -214,6 +214,7 @@ func createGateway(clusterName string, nameserver string, localAddress string, l
 		// advertised but not functional end-to-end (e.g. some GitHub Actions runners).
 		// For dual-stack or unspecified gateways, publish without an explicit address.
 		// See https://github.com/kubernetes-sigs/cloud-provider-kind/issues/387
+		hostPort := config.DefaultConfig.LoadBalancerPortMappingHostPort
 		seen := make(map[string]struct{})
 		for _, listener := range gateway.Spec.Listeners {
 			proto := "tcp"
@@ -223,10 +224,10 @@ func createGateway(clusterName string, nameserver string, localAddress string, l
 
 			var publishArg string
 			if listenAddress != "" {
-				hostPortBinding := net.JoinHostPort(listenAddress, fmt.Sprintf("%d", listener.Port))
+				hostPortBinding := net.JoinHostPort(listenAddress, fmt.Sprintf("%d", hostPort))
 				publishArg = fmt.Sprintf("--publish=%s:%d/%s", hostPortBinding, listener.Port, proto)
 			} else {
-				publishArg = fmt.Sprintf("--publish=%d/%s", listener.Port, proto)
+				publishArg = fmt.Sprintf("--publish=%d:%d/%s", hostPort, listener.Port, proto)
 			}
 
 			if _, exists := seen[publishArg]; exists {

--- a/pkg/loadbalancer/server.go
+++ b/pkg/loadbalancer/server.go
@@ -234,15 +234,16 @@ func (s *Server) createLoadBalancer(clusterName string, service *v1.Service, ima
 		// For dual-stack or unspecified services, publish without an explicit address.
 		// See https://github.com/kubernetes-sigs/cloud-provider-kind/issues/387
 		listenAddress := listenAddressForService(service)
+		hostPort := config.DefaultConfig.LoadBalancerPortMappingHostPort
 		for _, port := range service.Spec.Ports {
 			if port.Protocol != v1.ProtocolTCP && port.Protocol != v1.ProtocolUDP {
 				continue
 			}
 			if listenAddress != "" {
-				hostPortBinding := net.JoinHostPort(listenAddress, fmt.Sprintf("%d", port.Port))
+				hostPortBinding := net.JoinHostPort(listenAddress, fmt.Sprintf("%d", hostPort))
 				args = append(args, fmt.Sprintf("--publish=%s:%d/%s", hostPortBinding, port.Port, port.Protocol))
 			} else {
-				args = append(args, fmt.Sprintf("--publish=%d/%s", port.Port, port.Protocol))
+				args = append(args, fmt.Sprintf("--publish=%d:%d/%s", hostPort, port.Port, port.Protocol))
 			}
 		}
 	}


### PR DESCRIPTION
Closes https://github.com/kubernetes-sigs/cloud-provider-kind/issues/417