### PR TITLE
feat: enable IPv6/dual-stack admin listener config for Envoy bootstrap

### DIFF
--- a/pkg/loadbalancer/proxy.go
+++ b/pkg/loadbalancer/proxy.go
@@ -48,8 +48,9 @@ admin:
   access_log_path: /dev/stdout
   address:
     socket_address:
-      address: 0.0.0.0
+      address: "::"
       port_value: 10000
+      ipv4_compat: true
 `
 
 // proxyConfigData is supplied to the loadbalancer config template

--- a/pkg/loadbalancer/server.go
+++ b/pkg/loadbalancer/server.go
@@ -246,9 +246,9 @@ func (s *Server) createLoadBalancer(clusterName string, service *v1.Service, ima
 			}
 		}
 	}
-	// publish the admin endpoint
+	// explicitely publish the admin endpoint
 	args = append(args, fmt.Sprintf("--publish=%d/%s", envoyAdminPort, v1.ProtocolTCP))
-	// Publish all ports in the host in random ports
+	// publish all ports in the host on random ports
 	args = append(args, "--publish-all")
 
 	if service.Spec.LoadBalancerIP != "" {


### PR DESCRIPTION
Envoys admin port was always published as a generic dual-stack/random host port, while the admin listener itself was only safe on IPv4 unless IPv6 was actually enabled in the container. On macOS + Colima this could send /ready checks down an IPv6 path that accepted the TCP connection but returned an empty reply, which made load balancer startup flaky.

This change makes admin listener and port publishing consistent with actual IP-family support: IPv4-only setups stay IPv4-only, and IPv6-capable setups use a dual-stack Envoy admin listener plus dual-stack publishing.

Fixes #421 