### PR TITLE
Fix nil pointer panic in getRestConfig when one kubeconfig is unavailable

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -171,23 +171,28 @@ func (c *Controller) getRestConfig(ctx context.Context, cluster string) (*rest.C
 		}
 	}
 
-	var config *rest.Config
-	switch host {
-	case internalConfig.Host:
-		config = internalConfig
+	return selectRestConfig(internalConfig, externalConfig, host)
+}
+
+// selectRestConfig returns the rest.Config whose Host matches the host that was
+// successfully probed. internalConfig or externalConfig may be nil when the
+// corresponding kubeconfig could not be obtained, so their Host is only
+// compared when they are set to avoid a nil pointer dereference.
+func selectRestConfig(internalConfig, externalConfig *rest.Config, host string) (*rest.Config, error) {
+	switch {
+	case internalConfig != nil && host == internalConfig.Host:
 		// the first cluster will give us the type of connectivity between
 		// cloud-provider-kind and the clusters and load balancer containers.
 		// In Linux or containerized cloud-provider-kind this will be direct.
 		once.Do(func() {
 			cpkconfig.DefaultConfig.ControlPlaneConnectivity = cpkconfig.Direct
 		})
-	case externalConfig.Host:
-		config = externalConfig
+		return internalConfig, nil
+	case externalConfig != nil && host == externalConfig.Host:
+		return externalConfig, nil
 	default:
 		return nil, fmt.Errorf("restConfig for host %s not avaliable", host)
 	}
-
-	return config, nil
 }
 
 // TODO: implement leader election to not have problems with multiple providers

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -10,27 +10,74 @@ func Test_selectRestConfig(t *testing.T) {
 	internal := &rest.Config{Host: "https://internal:6443"}
 	external := &rest.Config{Host: "https://external:6443"}
 
-	// internal kubeconfig unavailable, only the external endpoint answered the
-	// probe: must not panic and must return the external config.
-	got, err := selectRestConfig(nil, external, external.Host)
-	if err != nil {
-		t.Fatalf("selectRestConfig() error = %v", err)
-	}
-	if got != external {
-		t.Errorf("selectRestConfig() = %v, want external config", got)
+	tests := []struct {
+		name           string
+		internalConfig *rest.Config
+		externalConfig *rest.Config
+		host           string
+		want           *rest.Config
+		wantErr        bool
+	}{
+		{
+			name:           "internal kubeconfig unavailable, external endpoint answered",
+			internalConfig: nil,
+			externalConfig: external,
+			host:           external.Host,
+			want:           external,
+		},
+		{
+			name:           "external kubeconfig unavailable, internal endpoint answered",
+			internalConfig: internal,
+			externalConfig: nil,
+			host:           internal.Host,
+			want:           internal,
+		},
+		{
+			name:           "both available, host matches internal",
+			internalConfig: internal,
+			externalConfig: external,
+			host:           internal.Host,
+			want:           internal,
+		},
+		{
+			name:           "both available, host matches external",
+			internalConfig: internal,
+			externalConfig: external,
+			host:           external.Host,
+			want:           external,
+		},
+		{
+			name:           "host matches neither available config",
+			internalConfig: internal,
+			externalConfig: external,
+			host:           "https://other:6443",
+			wantErr:        true,
+		},
+		{
+			name:           "only external available but host does not match",
+			internalConfig: nil,
+			externalConfig: external,
+			host:           internal.Host,
+			wantErr:        true,
+		},
+		{
+			name:           "both configs unavailable",
+			internalConfig: nil,
+			externalConfig: nil,
+			host:           internal.Host,
+			wantErr:        true,
+		},
 	}
 
-	// external kubeconfig unavailable, only the internal endpoint answered.
-	got, err = selectRestConfig(internal, nil, internal.Host)
-	if err != nil {
-		t.Fatalf("selectRestConfig() error = %v", err)
-	}
-	if got != internal {
-		t.Errorf("selectRestConfig() = %v, want internal config", got)
-	}
-
-	// host does not match any available config.
-	if _, err := selectRestConfig(nil, external, ""); err == nil {
-		t.Errorf("selectRestConfig() expected error for unmatched host, got nil")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := selectRestConfig(tt.internalConfig, tt.externalConfig, tt.host)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("selectRestConfig() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("selectRestConfig() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -1,0 +1,36 @@
+package controller
+
+import (
+	"testing"
+
+	"k8s.io/client-go/rest"
+)
+
+func Test_selectRestConfig(t *testing.T) {
+	internal := &rest.Config{Host: "https://internal:6443"}
+	external := &rest.Config{Host: "https://external:6443"}
+
+	// internal kubeconfig unavailable, only the external endpoint answered the
+	// probe: must not panic and must return the external config.
+	got, err := selectRestConfig(nil, external, external.Host)
+	if err != nil {
+		t.Fatalf("selectRestConfig() error = %v", err)
+	}
+	if got != external {
+		t.Errorf("selectRestConfig() = %v, want external config", got)
+	}
+
+	// external kubeconfig unavailable, only the internal endpoint answered.
+	got, err = selectRestConfig(internal, nil, internal.Host)
+	if err != nil {
+		t.Fatalf("selectRestConfig() error = %v", err)
+	}
+	if got != internal {
+		t.Errorf("selectRestConfig() = %v, want internal config", got)
+	}
+
+	// host does not match any available config.
+	if _, err := selectRestConfig(nil, external, ""); err == nil {
+		t.Errorf("selectRestConfig() expected error for unmatched host, got nil")
+	}
+}


### PR DESCRIPTION
`getRestConfig` calls `getKubeConfig` for both the internal and external endpoints and only logs on failure, so either `internalConfig` or `externalConfig` can be nil. The subsequent `switch host` then evaluates `case internalConfig.Host:` (and `externalConfig.Host`) unconditionally, which panics with a nil pointer dereference when the corresponding config is nil. This is the crash reported in #424: the internal kubeconfig fetch failed, only the external endpoint was probed, and selecting the config dereferenced the nil internal config.

The host selection is moved into `selectRestConfig`, which compares against each config's `Host` only when that config is non-nil and returns an error if no available config matches.

Fixes #424

/kind bug

```release-note
Fix a nil pointer panic in cloud-provider-kind when only one of the internal/external cluster endpoints is reachable.
```
