### PR TITLE
Error if no supported runtime is found

### DIFF
--- a/cmd/app.go
+++ b/cmd/app.go
@@ -199,7 +199,11 @@ func runE(cmd *cobra.Command, args []string) error {
 		}
 	}
 	if option == nil {
-		p := container.DetectRuntime()
+		p, err := container.DetectRuntime()
+		if err != nil {
+			return err
+		}
+
 		container.SetRuntime(p)
 		switch p {
 		case "podman":

--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -49,22 +49,23 @@ func SetRuntime(name string) {
 }
 
 // DetectRuntime probes the system for an available container runtime.
-func DetectRuntime() string {
+// It returns an error if no supported runtime is installed and running.
+func DetectRuntime() (string, error) {
 	if dockerIsAvailable() {
-		return "docker"
+		return "docker", nil
 	}
 	if podmanIsAvailable() {
-		return "podman"
+		return "podman", nil
 	}
 	if nerdctlIsAvailable() {
 		if _, err := exec.LookPath("nerdctl"); err != nil {
 			if _, err := exec.LookPath("finch"); err == nil {
-				return "finch"
+				return "finch", nil
 			}
 		}
-		return "nerdctl"
+		return "nerdctl", nil
 	}
-	return "docker"
+	return "", fmt.Errorf("no supported container runtime found")
 }
 
 func Logs(name string, w io.Writer) error {


### PR DESCRIPTION
We made the (not unreasonable) assumption that there would be a container runtime available when executing, and default to reporting docker if no other runtime could explicitly be detected.

If we did execute on a system without an available runtime, this would cause the unintended side effect that we would retry forever, treating the lack of a runtime as a transient error that should resolve eventually. This may or may not be what the user expects.

This changes the behavior to just error out of there is a runtime detection problem. It's likely the user will need to resolve whatever issue they have with their environment anyway, after which they can just rerun the command.

Closes: #430 