### PR TITLE
fix: reflect static spec.addresses in Gateway status and enabel the corresponding conformance tests

### DIFF
--- a/.github/workflows/gateway.yml
+++ b/.github/workflows/gateway.yml
@@ -11,6 +11,7 @@ env:
   K8S_VERSION: "v1.35.0"
   KIND_VERSION: "v0.31.0"
   KIND_CLUSTER_NAME: "kind-cloud"
+  KIND_EXPERIMENTAL_DOCKER_NETWORK: "kind-static"
 
 jobs:
   gateway:
@@ -55,6 +56,10 @@ jobs:
         sudo chmod +x /usr/local/bin/kind
         # Create folder to store artifacts
         mkdir -p _artifacts
+        # Create docker network with subnet
+        docker network create \
+        --driver=bridge \
+        --subnet=172.20.0.0/16 $KIND_EXPERIMENTAL_DOCKER_NETWORK
 
     - name: Run cloud-provider-kind
       run: |
@@ -110,11 +115,10 @@ jobs:
 
     - name: Run tests
       run: |
-        GATEWAY_ADDRESS=$(/usr/local/bin/kubectl get nodes ${{ env.KIND_CLUSTER_NAME }}-control-plane -o jsonpath='{.status.addresses[?(@.type=="InternalIP")].address}' | awk -F. '{print $1"."$2"."$3".100"}')
         /usr/local/bin/conformance.test -test.run 'TestConformance$' \
             --debug=true \
             --kubeconfig=_artifacts/kubeconfig.conf \
-            --usable-address=$GATEWAY_ADDRESS \
+            --usable-address=172.20.0.100 \
             --unusable-address=invalid.io \
             --organization=sigs.k8s.io \
             --project=cloud-provider-kind \

--- a/.github/workflows/gateway.yml
+++ b/.github/workflows/gateway.yml
@@ -110,9 +110,12 @@ jobs:
 
     - name: Run tests
       run: |
+        GATEWAY_ADDRESS=$(/usr/local/bin/kubectl get nodes ${{ env.KIND_CLUSTER_NAME }}-control-plane -o jsonpath='{.status.addresses[?(@.type=="InternalIP")].address}' | awk -F. '{print $1"."$2"."$3".100"}')
         /usr/local/bin/conformance.test -test.run 'TestConformance$' \
             --debug=true \
             --kubeconfig=_artifacts/kubeconfig.conf \
+            --usable-address=$GATEWAY_ADDRESS \
+            --unusable-address=invalid.io \
             --organization=sigs.k8s.io \
             --project=cloud-provider-kind \
             --url=https://github.com/kubernetes-sigs/cloud-provider-kind \

--- a/pkg/gateway/envoy.go
+++ b/pkg/gateway/envoy.go
@@ -200,11 +200,17 @@ func createGateway(clusterName string, nameserver string, localAddress string, l
 			}
 		}
 	}
-
-	args = append(args, []string{
-		"--sysctl=net.ipv6.conf.all.disable_ipv6=0",
-		"--sysctl=net.ipv6.conf.all.forwarding=1",
-	}...)
+	if len(gateway.Spec.Addresses) > 0 && ipv4 != "" && ipv6 == "" {
+		// Only the explicitly requested addresses should be assigned. Since none of them is IPv6, disable IPv6.
+		args = append(args, []string{
+			"--sysctl=net.ipv6.conf.all.disable_ipv6=1",
+		}...)
+	} else {
+		args = append(args, []string{
+			"--sysctl=net.ipv6.conf.all.disable_ipv6=0",
+			"--sysctl=net.ipv6.conf.all.forwarding=1",
+		}...)
+	}
 
 	if enableTunnel ||
 		config.DefaultConfig.LoadBalancerConnectivity == config.Portmap {

--- a/pkg/gateway/features.go
+++ b/pkg/gateway/features.go
@@ -33,6 +33,7 @@ var supportedFeatures = buildSupportedFeatures(
 	// Extended
 	features.SupportGatewayAddressEmpty,
 	features.SupportGatewayPort8080,
+	features.SupportGatewayStaticAddresses,
 	features.SupportHTTPRoute303RedirectStatusCode,
 	features.SupportHTTPRoute307RedirectStatusCode,
 	features.SupportHTTPRoute308RedirectStatusCode,

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -6,10 +6,9 @@ import (
 	"fmt"
 	"net"
 	"reflect"
+	"slices"
 	"strings"
 	"time"
-
-	"google.golang.org/protobuf/types/known/durationpb"
 
 	clusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -20,6 +19,7 @@ import (
 	envoyproxytypes "github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	cachev3 "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
 	resourcev3 "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
+	"google.golang.org/protobuf/types/known/durationpb"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -84,27 +84,11 @@ func (c *Controller) syncGateway(ctx context.Context, key string) error {
 	}
 
 	newGw := gw.DeepCopy()
-	var (
-		envoyResources    map[resourcev3.Type][]envoyproxytypes.Resource
-		httpRouteStatuses map[types.NamespacedName][]gatewayv1.RouteParentStatus
-		grpcRouteStatuses map[types.NamespacedName][]gatewayv1.RouteParentStatus
-	)
 
-	if gw.Spec.Infrastructure != nil && gw.Spec.Infrastructure.ParametersRef != nil {
-		meta.SetStatusCondition(&newGw.Status.Conditions, metav1.Condition{
-			Type:               string(gatewayv1.GatewayConditionAccepted),
-			Status:             metav1.ConditionFalse,
-			Reason:             string(gatewayv1.GatewayReasonInvalidParameters),
-			Message:            "infrastructure.parametersRef is not supported",
-			ObservedGeneration: newGw.Generation,
-		})
-	} else {
-		// Get the desired state
-		var listenerStatuses []gatewayv1.ListenerStatus
-		envoyResources, listenerStatuses, httpRouteStatuses, grpcRouteStatuses = c.buildEnvoyResourcesForGateway(newGw)
-		newGw.Status.Listeners = listenerStatuses
-		setAcceptedCondition(newGw)
-	}
+	// Get the desired state
+	envoyResources, listenerStatuses, httpRouteStatuses, grpcRouteStatuses := c.buildEnvoyResourcesForGateway(newGw)
+	newGw.Status.Listeners = listenerStatuses
+	setAcceptedCondition(newGw)
 
 	var xdsErr error
 	if meta.IsStatusConditionTrue(newGw.Status.Conditions, string(gatewayv1.GatewayConditionAccepted)) {
@@ -802,24 +786,32 @@ func createClusterLoadAssignment(clusterName, serviceHost string, servicePort ui
 	}
 }
 
-// getRouteHostnames determines the effective hostnames for a route.
-func getRouteHostnames(routeHostnames []gatewayv1.Hostname, listener gatewayv1.Listener) []string {
-	if len(routeHostnames) > 0 {
-		hostnames := make([]string, len(routeHostnames))
-		for i, h := range routeHostnames {
-			hostnames[i] = string(h)
-		}
-		return hostnames
-	}
-	if listener.Hostname != nil && *listener.Hostname != "" {
-		return []string{string(*listener.Hostname)}
-	}
-	return []string{"*"}
-}
-
-// setAcceptedCondition sets the Accepted condition on the Gateway based on how many
-// of its listeners are valid.
+// setAcceptedCondition sets the Accepted condition on the Gateway.
 func setAcceptedCondition(newGw *gatewayv1.Gateway) {
+	if newGw.Spec.Infrastructure != nil && newGw.Spec.Infrastructure.ParametersRef != nil {
+		meta.SetStatusCondition(&newGw.Status.Conditions, metav1.Condition{
+			Type:               string(gatewayv1.GatewayConditionAccepted),
+			Status:             metav1.ConditionFalse,
+			Reason:             string(gatewayv1.GatewayReasonInvalidParameters),
+			Message:            "infrastructure.parametersRef is not supported",
+			ObservedGeneration: newGw.Generation,
+		})
+		return
+	}
+
+	for _, address := range newGw.Spec.Addresses {
+		if address.Type != nil && *address.Type != gatewayv1.IPAddressType && *address.Type != gatewayv1.HostnameAddressType {
+			meta.SetStatusCondition(&newGw.Status.Conditions, metav1.Condition{
+				Type:               string(gatewayv1.GatewayConditionAccepted),
+				Status:             metav1.ConditionFalse,
+				Reason:             string(gatewayv1.GatewayReasonUnsupportedAddress),
+				Message:            fmt.Sprintf("Address type %s is not supported", *address.Type),
+				ObservedGeneration: newGw.Generation,
+			})
+			return
+		}
+	}
+
 	var invalidListeners int
 	for _, ls := range newGw.Status.Listeners {
 		if meta.IsStatusConditionFalse(ls.Conditions, string(gatewayv1.ListenerConditionAccepted)) {
@@ -857,41 +849,81 @@ func setAcceptedCondition(newGw *gatewayv1.Gateway) {
 // setProgrammedCondition sets the Programmed condition for the Gateway.
 // Accepted is expected to already be set on newGw by the time this is called.
 func setProgrammedCondition(newGw *gatewayv1.Gateway, xdsErr error) {
-	programmedCondition := metav1.Condition{
-		Type:               string(gatewayv1.GatewayConditionProgrammed),
-		ObservedGeneration: newGw.Generation,
-	}
-	// A Gateway can never be Programmed=True if Accepted=False.
 	switch {
 	case meta.IsStatusConditionFalse(newGw.Status.Conditions, string(gatewayv1.GatewayConditionAccepted)):
-		programmedCondition.Status = metav1.ConditionFalse
-		programmedCondition.Reason = string(gatewayv1.GatewayReasonInvalid)
-		programmedCondition.Message = "Gateway is not accepted"
+		// A Gateway can never be Programmed=True if Accepted=False.
+		meta.SetStatusCondition(&newGw.Status.Conditions, metav1.Condition{
+			Type:               string(gatewayv1.GatewayConditionProgrammed),
+			Status:             metav1.ConditionFalse,
+			Reason:             string(gatewayv1.GatewayReasonInvalid),
+			Message:            "Gateway is not accepted",
+			ObservedGeneration: newGw.Generation,
+		})
 	case xdsErr != nil:
 		// If the Envoy update fails, the Gateway is not programmed.
-		programmedCondition.Status = metav1.ConditionFalse
-		programmedCondition.Reason = "ReconciliationError"
-		programmedCondition.Message = fmt.Sprintf("Failed to program envoy config: %s", xdsErr.Error())
+		meta.SetStatusCondition(&newGw.Status.Conditions, metav1.Condition{
+			Type:               string(gatewayv1.GatewayConditionProgrammed),
+			Status:             metav1.ConditionFalse,
+			Reason:             "ReconciliationError",
+			Message:            fmt.Sprintf("Failed to program envoy config: %s", xdsErr.Error()),
+			ObservedGeneration: newGw.Generation,
+		})
 	default:
-		// If the Envoy update succeeds, check if all individual listeners were programmed.
-		total := len(newGw.Status.Listeners)
+		// If the Envoy update succeeds:
+
+		// Check if all addresses were assigned.
+		totalAddresses := len(newGw.Spec.Addresses)
+		addressAssigned := 0
+		for _, address := range newGw.Spec.Addresses {
+			if slices.ContainsFunc(newGw.Status.Addresses, func(statusAddress gatewayv1.GatewayStatusAddress) bool {
+				if (statusAddress.Type != nil) != (address.Type != nil) {
+					return false
+				}
+				if statusAddress.Type != nil && address.Type != nil {
+					return *statusAddress.Type == *address.Type && statusAddress.Value == address.Value
+				}
+				return statusAddress.Value == address.Value
+			}) {
+				addressAssigned++
+			}
+		}
+		if addressAssigned != totalAddresses {
+			meta.SetStatusCondition(&newGw.Status.Conditions, metav1.Condition{
+				Type:               string(gatewayv1.GatewayConditionProgrammed),
+				Status:             metav1.ConditionFalse,
+				Reason:             string(gatewayv1.GatewayReasonAddressNotUsable),
+				Message:            fmt.Sprintf("%d out of %d addresses failed to be assigned", totalAddresses-addressAssigned, totalAddresses),
+				ObservedGeneration: newGw.Generation,
+			})
+			return
+		}
+
+		// Check if all individual listeners were programmed.
+		totalListeners := len(newGw.Status.Listeners)
 		listenersProgrammed := 0
 		for _, ls := range newGw.Status.Listeners {
 			if meta.IsStatusConditionTrue(ls.Conditions, string(gatewayv1.ListenerConditionProgrammed)) {
 				listenersProgrammed++
 			}
 		}
-		if listenersProgrammed == total {
+		if listenersProgrammed == totalListeners {
 			// The Gateway is only fully programmed if all listeners are programmed.
-			programmedCondition.Status = metav1.ConditionTrue
-			programmedCondition.Reason = string(gatewayv1.GatewayReasonProgrammed)
-			programmedCondition.Message = "Envoy configuration updated successfully"
+			meta.SetStatusCondition(&newGw.Status.Conditions, metav1.Condition{
+				Type:               string(gatewayv1.GatewayConditionProgrammed),
+				Status:             metav1.ConditionTrue,
+				Reason:             string(gatewayv1.GatewayReasonProgrammed),
+				Message:            "Envoy configuration updated successfully",
+				ObservedGeneration: newGw.Generation,
+			})
 		} else {
 			// If any listener failed, the Gateway as a whole is not fully programmed.
-			programmedCondition.Status = metav1.ConditionFalse
-			programmedCondition.Reason = "ListenersNotProgrammed"
-			programmedCondition.Message = fmt.Sprintf("%d out of %d listeners failed to be programmed", listenersProgrammed, total)
+			meta.SetStatusCondition(&newGw.Status.Conditions, metav1.Condition{
+				Type:               string(gatewayv1.GatewayConditionProgrammed),
+				Status:             metav1.ConditionFalse,
+				Reason:             "ListenersNotProgrammed",
+				Message:            fmt.Sprintf("%d out of %d listeners failed to be programmed", totalListeners-listenersProgrammed, totalListeners),
+				ObservedGeneration: newGw.Generation,
+			})
 		}
 	}
-	meta.SetStatusCondition(&newGw.Status.Conditions, programmedCondition)
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it:**
cloud-provider-kind already supports `.spec.addresses` on Gateways, but the behavior does not match what the Gateway API conformance tests expect. This PR enables the `SupportGatewayStaticAddresses` feature and the corresponding conformance test, and fixes the status update to correctly set the `Accepted` and `Programmed` conditions when a requested address type is unsupported or otherwise unusable.

In addition, IPv6 is no longer enabled implicitly for Gateways that request only IPv4 addresses.