### PR TITLE
gateway: implement GEP-1494 ExternalAuth HTTPRoute filter

### DIFF
--- a/.github/workflows/bats.yml
+++ b/.github/workflows/bats.yml
@@ -42,6 +42,14 @@ jobs:
         run: |
           bats -o _artifacts-custom-network tests/custom-network/
 
+      - name: Bats tests (gateway experimental channel)
+        shell: bash
+        env:
+          BATS_LIB_PATH: ${{ steps.setup-bats.outputs.lib-path }}
+          TERM: xterm
+        run: |
+          bats -o _artifacts-gateway-experimental tests/gateway-experimental/
+
       - name: Upload logs
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v5
@@ -50,6 +58,7 @@ jobs:
           path: |
             ./_artifacts
             ./_artifacts-custom-network
+            ./_artifacts-gateway-experimental
  
   bats_mac_tests:
     runs-on: macos-15-intel

--- a/docs/user/gateway/gatewayapi.md
+++ b/docs/user/gateway/gatewayapi.md
@@ -10,3 +10,32 @@ using the flag `gateway-channel`:
 ```sh
 cloud-provider-kind --gateway-channel standard|experimental|disabled
 ```
+
+### HTTP external authorization (GEP-1494)
+
+The experimental channel adds the `ExternalAuth` HTTPRoute filter described in
+[GEP-1494](https://gateway-api.sigs.k8s.io/geps/gep-1494/). It delegates
+authentication and authorization for a route rule to an external server that
+speaks Envoy's `ext_authz` protocol, over either `HTTP` or `GRPC`:
+
+```yaml
+    filters:
+    - type: ExternalAuth
+      externalAuth:
+        protocol: HTTP
+        backendRef:
+          name: authz-svc
+          port: 8080
+        http:
+          path: /auth
+          allowedHeaders:
+          - X-Request-Id
+          allowedResponseHeaders:
+          - X-Authenticated-User
+```
+
+Requests only reach the backends when the authorization server approves them.
+If the server is unreachable, or the `backendRef` cannot be resolved, the rule
+fails closed and the route reports `ResolvedRefs=False`.
+
+See `examples/gateway_external_auth.yaml` for a complete example.

--- a/examples/gateway_external_auth.yaml
+++ b/examples/gateway_external_auth.yaml
@@ -1,0 +1,146 @@
+# GEP-1494: HTTP external authorization for an HTTPRoute rule.
+#
+# Requires the Gateway API experimental channel:
+#   cloud-provider-kind --gateway-channel experimental
+#
+# Every request matched by the rule is sent to the authz service first. The
+# service returns 200 when the request carries an Authorization header and 401
+# otherwise, so only authenticated requests reach myapp-svc.
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: prod-web
+spec:
+  gatewayClassName: cloud-provider-kind
+  listeners:
+  - protocol: HTTP
+    port: 80
+    name: prod-web-gw
+    allowedRoutes:
+      namespaces:
+        from: Same
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: secure
+spec:
+  parentRefs:
+  - name: prod-web
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /
+    filters:
+    - type: ExternalAuth
+      externalAuth:
+        protocol: HTTP
+        backendRef:
+          name: authz-svc
+          port: 8080
+        http:
+          path: /auth
+          allowedHeaders:
+          - X-Request-Id
+          allowedResponseHeaders:
+          - X-Authenticated-User
+    backendRefs:
+    - name: myapp-svc
+      port: 8080
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: authz-conf
+data:
+  default.conf: |
+    server {
+      listen 8080;
+      location / {
+        if ($http_authorization = "") {
+          return 401;
+        }
+        add_header X-Authenticated-User "demo";
+        return 200;
+      }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: authz
+spec:
+  selector:
+    matchLabels:
+      app: Authz
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: Authz
+    spec:
+      containers:
+      - name: authz
+        image: nginx:1.29-alpine
+        ports:
+        - name: http
+          containerPort: 8080
+        volumeMounts:
+        - name: conf
+          mountPath: /etc/nginx/conf.d
+      volumes:
+      - name: conf
+        configMap:
+          name: authz-conf
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: authz-svc
+spec:
+  type: ClusterIP
+  selector:
+    app: Authz
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myapp
+spec:
+  selector:
+    matchLabels:
+      app: MyApp
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: MyApp
+    spec:
+      containers:
+      - name: myapp
+        image: registry.k8s.io/e2e-test-images/agnhost:2.66.1
+        args:
+        - netexec
+        - --http-port=80
+        - --delay-shutdown=30
+        ports:
+        - name: httpd
+          containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: myapp-svc
+spec:
+  type: ClusterIP
+  selector:
+    app: MyApp
+  ports:
+  - name: httpd
+    port: 8080
+    targetPort: 80

--- a/pkg/gateway/controller.go
+++ b/pkg/gateway/controller.go
@@ -388,7 +388,7 @@ func (c *Controller) syncGatewayClass(key string) {
 		ObservedGeneration: gwc.Generation,
 	})
 	// Advertise the features this controller supports (GEP-2162).
-	newGwc.Status.SupportedFeatures = supportedFeatures
+	newGwc.Status.SupportedFeatures = supportedFeaturesForChannel(config.DefaultConfig.GatewayReleaseChannel)
 
 	// Update the status on the API server.
 	if _, err := c.gwClient.GatewayV1().GatewayClasses().UpdateStatus(context.Background(), newGwc, metav1.UpdateOptions{}); err != nil {

--- a/pkg/gateway/externalauth.go
+++ b/pkg/gateway/externalauth.go
@@ -32,6 +32,7 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
 
+	corev1 "k8s.io/api/core/v1"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewaylistersv1 "sigs.k8s.io/gateway-api/pkg/client/listers/apis/v1"
@@ -128,14 +129,32 @@ func resolveExternalAuthBackend(
 		}
 	}
 
-	if _, err := serviceLister.Services(ns).Get(string(backendRef.Name)); err != nil {
+	svc, err := serviceLister.Services(ns).Get(string(backendRef.Name))
+	if err != nil {
 		return "", &ControllerError{
 			Reason:  string(gatewayv1.RouteReasonBackendNotFound),
 			Message: fmt.Sprintf("externalAuth backend Service %s/%s not found", ns, backendRef.Name),
 		}
 	}
+	port := int32(*backendRef.Port)
+	if !serviceHasPort(svc, port) {
+		return "", &ControllerError{
+			Reason:  string(gatewayv1.RouteReasonBackendNotFound),
+			Message: fmt.Sprintf("externalAuth backend Service %s/%s does not have port %d", ns, backendRef.Name, port),
+		}
+	}
 
-	return externalAuthClusterName(ns, string(backendRef.Name), int32(*backendRef.Port)), nil
+	return externalAuthClusterName(ns, string(backendRef.Name), port), nil
+}
+
+// serviceHasPort reports whether svc exposes the given Service port.
+func serviceHasPort(svc *corev1.Service, port int32) bool {
+	for _, p := range svc.Spec.Ports {
+		if p.Port == port {
+			return true
+		}
+	}
+	return false
 }
 
 // externalAuthClusterName returns the Envoy cluster name for an authorization server.

--- a/pkg/gateway/externalauth.go
+++ b/pkg/gateway/externalauth.go
@@ -1,0 +1,375 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gateway
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"time"
+
+	clusterv3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	mutationrulesv3 "github.com/envoyproxy/go-control-plane/envoy/config/common/mutation_rules/v3"
+	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	extauthzv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_authz/v3"
+	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	upstreamsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
+	matcherv3 "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/durationpb"
+
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewaylistersv1 "sigs.k8s.io/gateway-api/pkg/client/listers/apis/v1"
+)
+
+// GEP-1494 (HTTP Auth in Gateway API) is implemented on top of Envoy's ext_authz
+// filter. The authorization server is per HTTPRoute rule, but Envoy only allows
+// the server to be configured on the HTTP filter itself, so a distinct (disabled
+// by default) ext_authz filter is installed in the connection manager for every
+// unique ExternalAuth configuration, and each route enables the one it needs
+// through `typed_per_filter_config`.
+const (
+	// externalAuthFilterPrefix namespaces the generated Envoy HTTP filter names.
+	externalAuthFilterPrefix = "envoy.filters.http.ext_authz.gateway-api"
+	// externalAuthTimeout bounds how long a request waits for the authorization server.
+	externalAuthTimeout = 5 * time.Second
+)
+
+// externalAuthResources holds the Envoy resources derived from an ExternalAuth filter.
+type externalAuthResources struct {
+	// httpFilter is installed disabled on the connection manager and enabled per route.
+	httpFilter *hcm.HttpFilter
+	// cluster is the upstream for the authorization server.
+	cluster *clusterv3.Cluster
+}
+
+// enableExtAuthzPerRoute is the typed_per_filter_config value that turns on an
+// ext_authz filter that is disabled by default. It carries no configuration, so
+// a single shared instance is enough.
+var enableExtAuthzPerRoute = mustEnableExtAuthzPerRoute()
+
+func mustEnableExtAuthzPerRoute() *anypb.Any {
+	cfg, err := anypb.New(&extauthzv3.ExtAuthzPerRoute{
+		Override: &extauthzv3.ExtAuthzPerRoute_CheckSettings{
+			CheckSettings: &extauthzv3.CheckSettings{},
+		},
+	})
+	if err != nil {
+		panic(fmt.Sprintf("marshalling a constant ExtAuthzPerRoute cannot fail: %v", err))
+	}
+	return cfg
+}
+
+// resolveExternalAuthBackend validates the ExternalAuth backendRef and returns the
+// Envoy cluster name to use for the authorization server.
+func resolveExternalAuthBackend(
+	routeNamespace string,
+	extAuth *gatewayv1.HTTPExternalAuthFilter,
+	serviceLister corev1listers.ServiceLister,
+	referenceGrantLister gatewaylistersv1.ReferenceGrantLister,
+) (string, error) {
+	backendRef := extAuth.BackendRef
+
+	if backendRef.Group != nil && *backendRef.Group != "" {
+		return "", &ControllerError{
+			Reason:  string(gatewayv1.RouteReasonInvalidKind),
+			Message: fmt.Sprintf("unsupported externalAuth backend group: %s", *backendRef.Group),
+		}
+	}
+	if backendRef.Kind != nil && *backendRef.Kind != "Service" {
+		return "", &ControllerError{
+			Reason:  string(gatewayv1.RouteReasonInvalidKind),
+			Message: fmt.Sprintf("unsupported externalAuth backend kind: %s", *backendRef.Kind),
+		}
+	}
+	if backendRef.Port == nil {
+		return "", &ControllerError{
+			Reason:  string(gatewayv1.RouteReasonUnsupportedProtocol),
+			Message: "externalAuth backend port must be specified",
+		}
+	}
+
+	ns := routeNamespace
+	if backendRef.Namespace != nil {
+		ns = string(*backendRef.Namespace)
+	}
+
+	if ns != routeNamespace {
+		from := gatewayv1.ReferenceGrantFrom{
+			Group:     gatewayv1.GroupName,
+			Kind:      "HTTPRoute",
+			Namespace: gatewayv1.Namespace(routeNamespace),
+		}
+		to := gatewayv1.ReferenceGrantTo{
+			Group: "", // Core group for Service
+			Kind:  "Service",
+			Name:  &backendRef.Name,
+		}
+		if !isCrossNamespaceRefAllowed(from, to, ns, referenceGrantLister) {
+			return "", &ControllerError{
+				Reason:  string(gatewayv1.RouteReasonRefNotPermitted),
+				Message: fmt.Sprintf("reference to Service %s/%s not permitted by any ReferenceGrant", ns, backendRef.Name),
+			}
+		}
+	}
+
+	if _, err := serviceLister.Services(ns).Get(string(backendRef.Name)); err != nil {
+		return "", &ControllerError{
+			Reason:  string(gatewayv1.RouteReasonBackendNotFound),
+			Message: fmt.Sprintf("externalAuth backend Service %s/%s not found", ns, backendRef.Name),
+		}
+	}
+
+	return externalAuthClusterName(ns, string(backendRef.Name), int32(*backendRef.Port)), nil
+}
+
+// externalAuthClusterName returns the Envoy cluster name for an authorization server.
+// It is kept distinct from regular backend clusters because the authorization
+// cluster may need different protocol options (HTTP/2 for the gRPC protocol).
+func externalAuthClusterName(namespace, name string, port int32) string {
+	return fmt.Sprintf("extauth_%s_%s_core_Service_%d", namespace, name, port)
+}
+
+// buildExtAuthzConfig translates an ExternalAuth filter into Envoy's ext_authz config.
+func buildExtAuthzConfig(extAuth *gatewayv1.HTTPExternalAuthFilter, clusterName, authority string) (*extauthzv3.ExtAuthz, error) {
+	extAuthz := &extauthzv3.ExtAuthz{
+		TransportApiVersion: corev3.ApiVersion_V3,
+		// A request must never reach the backend when the authorization server
+		// is unreachable or returns an error.
+		FailureModeAllow: false,
+		// Reject responses from the authorization server that try to inject
+		// malformed headers into the request.
+		ValidateMutations: true,
+		// GEP-1494 lets an authorization server copy every response header into
+		// the upstream request. The defaults of HeaderMutationRules keep that
+		// from rewriting Host, the :-prefixed routing headers and x-envoy-*.
+		DecoderHeaderMutationRules: &mutationrulesv3.HeaderMutationRules{},
+	}
+
+	switch extAuth.ExternalAuthProtocol {
+	case gatewayv1.HTTPRouteExternalAuthGRPCProtocol:
+		extAuthz.Services = &extauthzv3.ExtAuthz_GrpcService{
+			GrpcService: &corev3.GrpcService{
+				TargetSpecifier: &corev3.GrpcService_EnvoyGrpc_{
+					EnvoyGrpc: &corev3.GrpcService_EnvoyGrpc{ClusterName: clusterName},
+				},
+				Timeout: durationpb.New(externalAuthTimeout),
+			},
+		}
+		// When empty the Gateway API defaults apply, which match Envoy's own
+		// default set of headers forwarded to a gRPC authorization server.
+		if extAuth.GRPCAuthConfig != nil && len(extAuth.GRPCAuthConfig.AllowedRequestHeaders) > 0 {
+			extAuthz.AllowedHeaders = exactStringMatchers(extAuth.GRPCAuthConfig.AllowedRequestHeaders)
+		}
+
+	case gatewayv1.HTTPRouteExternalAuthHTTPProtocol:
+		httpService := &extauthzv3.HttpService{
+			ServerUri: &corev3.HttpUri{
+				Uri:              fmt.Sprintf("http://%s", authority),
+				HttpUpstreamType: &corev3.HttpUri_Cluster{Cluster: clusterName},
+				Timeout:          durationpb.New(externalAuthTimeout),
+			},
+		}
+		if extAuth.HTTPAuthConfig != nil {
+			httpService.PathPrefix = extAuth.HTTPAuthConfig.Path
+			if len(extAuth.HTTPAuthConfig.AllowedRequestHeaders) > 0 {
+				httpService.AuthorizationRequest = &extauthzv3.AuthorizationRequest{
+					AllowedHeaders: exactStringMatchers(extAuth.HTTPAuthConfig.AllowedRequestHeaders),
+				}
+			}
+			httpService.AuthorizationResponse = &extauthzv3.AuthorizationResponse{
+				AllowedUpstreamHeaders: responseHeaderMatchers(extAuth.HTTPAuthConfig.AllowedResponseHeaders),
+			}
+		} else {
+			httpService.AuthorizationResponse = &extauthzv3.AuthorizationResponse{
+				AllowedUpstreamHeaders: responseHeaderMatchers(nil),
+			}
+		}
+		extAuthz.Services = &extauthzv3.ExtAuthz_HttpService{HttpService: httpService}
+
+	default:
+		return nil, &ControllerError{
+			Reason:  string(gatewayv1.RouteReasonUnsupportedValue),
+			Message: fmt.Sprintf("unsupported externalAuth protocol: %q", extAuth.ExternalAuthProtocol),
+		}
+	}
+
+	if extAuth.ForwardBody != nil && extAuth.ForwardBody.MaxSize > 0 {
+		extAuthz.WithRequestBody = &extauthzv3.BufferSettings{
+			MaxRequestBytes:     uint32(extAuth.ForwardBody.MaxSize),
+			AllowPartialMessage: false, // GEP-1494
+			PackAsBytes:         extAuth.ExternalAuthProtocol == gatewayv1.HTTPRouteExternalAuthGRPCProtocol,
+		}
+	}
+
+	return extAuthz, nil
+}
+
+// exactStringMatchers builds a case-insensitive exact matcher list for header names.
+func exactStringMatchers(names []string) *matcherv3.ListStringMatcher {
+	list := &matcherv3.ListStringMatcher{}
+	for _, name := range names {
+		list.Patterns = append(list.Patterns, &matcherv3.StringMatcher{
+			IgnoreCase:   true,
+			MatchPattern: &matcherv3.StringMatcher_Exact{Exact: name},
+		})
+	}
+	return list
+}
+
+// responseHeaderMatchers builds the matcher for headers copied from the
+// authorization response into the request sent upstream. An empty list means
+// "copy everything" as required by GEP-1494; the filter's header mutation rules
+// keep Host and the other routing headers out of reach.
+func responseHeaderMatchers(names []string) *matcherv3.ListStringMatcher {
+	if len(names) == 0 {
+		return &matcherv3.ListStringMatcher{
+			Patterns: []*matcherv3.StringMatcher{{
+				MatchPattern: &matcherv3.StringMatcher_SafeRegex{
+					SafeRegex: &matcherv3.RegexMatcher{
+						EngineType: &matcherv3.RegexMatcher_GoogleRe2{GoogleRe2: &matcherv3.RegexMatcher_GoogleRE2{}},
+						Regex:      ".*",
+					},
+				},
+			}},
+		}
+	}
+	return exactStringMatchers(names)
+}
+
+// buildExternalAuthFilter renders the Envoy HTTP filter for an ExternalAuth
+// configuration. The name is a digest of the rendered configuration so that
+// identical configurations share one filter. It is only meaningful within a
+// single reconcile and must never be persisted or compared across builds.
+func buildExternalAuthFilter(extAuth *gatewayv1.HTTPExternalAuthFilter, clusterName, authority string) (string, *hcm.HttpFilter, error) {
+	extAuthz, err := buildExtAuthzConfig(extAuth, clusterName, authority)
+	if err != nil {
+		return "", nil, err
+	}
+
+	serialized, err := proto.MarshalOptions{Deterministic: true}.Marshal(extAuthz)
+	if err != nil {
+		return "", nil, err
+	}
+	sum := sha256.Sum256(serialized)
+	name := fmt.Sprintf("%s.%x", externalAuthFilterPrefix, sum[:8])
+
+	typedConfig, err := anypb.New(extAuthz)
+	if err != nil {
+		return "", nil, err
+	}
+
+	return name, &hcm.HttpFilter{
+		Name: name,
+		// The filter only applies to the routes that opt in through
+		// typed_per_filter_config.
+		Disabled: true,
+		ConfigType: &hcm.HttpFilter_TypedConfig{
+			TypedConfig: typedConfig,
+		},
+	}, nil
+}
+
+// resolveRuleExternalAuth builds the Envoy resources for every ExternalAuth
+// filter of an HTTPRoute rule, keyed by the connection manager filter name that
+// the rule's routes must reference. Resolution is all or nothing: any failure
+// leaves the rule with no authorization at all, so the caller has to fail it
+// closed rather than forward unauthorized traffic.
+func resolveRuleExternalAuth(
+	routeNamespace string,
+	filters []gatewayv1.HTTPRouteFilter,
+	serviceLister corev1listers.ServiceLister,
+	referenceGrantLister gatewaylistersv1.ReferenceGrantLister,
+) (map[string]*externalAuthResources, error) {
+	var resolved map[string]*externalAuthResources
+
+	for _, filter := range filters {
+		if filter.Type != gatewayv1.HTTPRouteFilterExternalAuth || filter.ExternalAuth == nil {
+			continue
+		}
+		extAuth := filter.ExternalAuth
+
+		clusterName, err := resolveExternalAuthBackend(routeNamespace, extAuth, serviceLister, referenceGrantLister)
+		if err != nil {
+			return nil, err
+		}
+		name, httpFilter, err := buildExternalAuthFilter(extAuth, clusterName, externalAuthAuthority(routeNamespace, extAuth))
+		if err != nil {
+			return nil, err
+		}
+		cluster, err := externalAuthCluster(serviceLister, routeNamespace, clusterName, extAuth)
+		if err != nil {
+			return nil, err
+		}
+
+		if resolved == nil {
+			resolved = make(map[string]*externalAuthResources)
+		}
+		resolved[name] = &externalAuthResources{httpFilter: httpFilter, cluster: cluster}
+	}
+
+	return resolved, nil
+}
+
+// externalAuthAuthority returns the value used as the Host header of the
+// requests sent to an HTTP authorization server.
+func externalAuthAuthority(routeNamespace string, extAuth *gatewayv1.HTTPExternalAuthFilter) string {
+	ns := routeNamespace
+	if extAuth.BackendRef.Namespace != nil {
+		ns = string(*extAuth.BackendRef.Namespace)
+	}
+	port := int32(0)
+	if extAuth.BackendRef.Port != nil {
+		port = int32(*extAuth.BackendRef.Port)
+	}
+	return fmt.Sprintf("%s.%s.svc.cluster.local:%d", extAuth.BackendRef.Name, ns, port)
+}
+
+// externalAuthCluster builds the Envoy cluster for an authorization server.
+func externalAuthCluster(serviceLister corev1listers.ServiceLister, routeNamespace, clusterName string, extAuth *gatewayv1.HTTPExternalAuthFilter) (*clusterv3.Cluster, error) {
+	backendRef := gatewayv1.BackendRef{BackendObjectReference: extAuth.BackendRef}
+	cluster, err := translateBackendRefToCluster(serviceLister, routeNamespace, backendRef)
+	if err != nil {
+		return nil, err
+	}
+	cluster.Name = clusterName
+	if cluster.LoadAssignment != nil {
+		cluster.LoadAssignment.ClusterName = clusterName
+	}
+
+	// Envoy's ext_authz gRPC client requires an HTTP/2 upstream.
+	if extAuth.ExternalAuthProtocol == gatewayv1.HTTPRouteExternalAuthGRPCProtocol {
+		protocolOptions, err := anypb.New(&upstreamsv3.HttpProtocolOptions{
+			UpstreamProtocolOptions: &upstreamsv3.HttpProtocolOptions_ExplicitHttpConfig_{
+				ExplicitHttpConfig: &upstreamsv3.HttpProtocolOptions_ExplicitHttpConfig{
+					ProtocolConfig: &upstreamsv3.HttpProtocolOptions_ExplicitHttpConfig_Http2ProtocolOptions{
+						Http2ProtocolOptions: &corev3.Http2ProtocolOptions{},
+					},
+				},
+			},
+		})
+		if err != nil {
+			return nil, err
+		}
+		cluster.TypedExtensionProtocolOptions = map[string]*anypb.Any{
+			"envoy.extensions.upstreams.http.v3.HttpProtocolOptions": protocolOptions,
+		}
+	}
+
+	return cluster, nil
+}

--- a/pkg/gateway/externalauth_test.go
+++ b/pkg/gateway/externalauth_test.go
@@ -87,6 +87,11 @@ func TestResolveExternalAuthBackend(t *testing.T) {
 			wantReason: string(gatewayv1.RouteReasonBackendNotFound),
 		},
 		{
+			name:       "existing service, missing port",
+			extAuth:    httpExternalAuth("", "authz", 9999),
+			wantReason: string(gatewayv1.RouteReasonBackendNotFound),
+		},
+		{
 			name: "unsupported kind",
 			extAuth: func() *gatewayv1.HTTPExternalAuthFilter {
 				e := httpExternalAuth("", "authz", 9000)
@@ -322,6 +327,98 @@ func TestTranslateHTTPRouteWithExternalAuth(t *testing.T) {
 	}
 	if _, ok := got.routes[0].Action.(*routev3.Route_Route); !ok {
 		t.Errorf("expected a forwarding action, got %T", got.routes[0].Action)
+	}
+}
+
+func TestTranslateHTTPRouteWithExternalAuthInvalidPort(t *testing.T) {
+	svcLister := newMockServiceLister(makeService("default", "svc", 80), makeService("default", "authz", 9000))
+	noGrants := newFakeReferenceGrantLister(nil, nil)
+
+	route := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "route", Generation: 1},
+		Spec: gatewayv1.HTTPRouteSpec{
+			Rules: []gatewayv1.HTTPRouteRule{makeRuleWithFilters(externalAuthFilter(httpExternalAuth("", "authz", 9999)))},
+		},
+	}
+
+	got := translateHTTPRouteToEnvoyRoutes(route, svcLister, noGrants)
+	if got.resolvedRefsFailure == nil {
+		t.Fatal("expected ResolvedRefs=False when the authorization server port does not exist")
+	}
+	if got.resolvedRefsFailure.Reason != string(gatewayv1.RouteReasonBackendNotFound) {
+		t.Errorf("got reason %q, want %q", got.resolvedRefsFailure.Reason, gatewayv1.RouteReasonBackendNotFound)
+	}
+	if got.partiallyInvalid != nil {
+		t.Errorf("a single invalid ExternalAuth rule must not set PartiallyInvalid, got %v", got.partiallyInvalid.Message)
+	}
+	if len(got.routes) != 1 {
+		t.Fatalf("got %d routes, want 1", len(got.routes))
+	}
+	direct, ok := got.routes[0].Action.(*routev3.Route_DirectResponse)
+	if !ok {
+		t.Fatalf("expected the request to fail closed, got %T", got.routes[0].Action)
+	}
+	if direct.DirectResponse.Status != 500 {
+		t.Errorf("got status %d, want 500", direct.DirectResponse.Status)
+	}
+}
+
+func TestTranslateHTTPRouteWithMixedExternalAuthValidity(t *testing.T) {
+	svcLister := newMockServiceLister(
+		makeService("default", "svc", 80),
+		makeAuthService("default", "authz", 9000, "10.0.0.10"),
+	)
+	noGrants := newFakeReferenceGrantLister(nil, nil)
+
+	valid := makeRuleWithFilters(externalAuthFilter(httpExternalAuth("", "authz", 9000)))
+	valid.Matches = []gatewayv1.HTTPRouteMatch{{
+		Path: &gatewayv1.HTTPPathMatch{
+			Type:  ptr.To(gatewayv1.PathMatchPathPrefix),
+			Value: ptr.To("/external-auth/valid"),
+		},
+	}}
+	invalid := makeRuleWithFilters(externalAuthFilter(httpExternalAuth("", "missing", 9000)))
+	invalid.Matches = []gatewayv1.HTTPRouteMatch{{
+		Path: &gatewayv1.HTTPPathMatch{
+			Type:  ptr.To(gatewayv1.PathMatchPathPrefix),
+			Value: ptr.To("/external-auth/invalid"),
+		},
+	}}
+
+	route := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "route", Generation: 1},
+		Spec: gatewayv1.HTTPRouteSpec{
+			Rules: []gatewayv1.HTTPRouteRule{valid, invalid},
+		},
+	}
+
+	got := translateHTTPRouteToEnvoyRoutes(route, svcLister, noGrants)
+	if got.notAccepted != nil {
+		t.Fatalf("route was rejected: %v", got.notAccepted.Message)
+	}
+	if got.resolvedRefsFailure == nil {
+		t.Fatal("expected ResolvedRefs=False when one ExternalAuth backend cannot be resolved")
+	}
+	if got.resolvedRefsFailure.Reason != string(gatewayv1.RouteReasonBackendNotFound) {
+		t.Errorf("got reason %q, want %q", got.resolvedRefsFailure.Reason, gatewayv1.RouteReasonBackendNotFound)
+	}
+	if got.partiallyInvalid == nil {
+		t.Fatal("expected PartiallyInvalid=True when one ExternalAuth rule is valid and another is not")
+	}
+	if got.partiallyInvalid.Reason != string(gatewayv1.RouteReasonUnsupportedValue) {
+		t.Errorf("got PartiallyInvalid reason %q, want %q", got.partiallyInvalid.Reason, gatewayv1.RouteReasonUnsupportedValue)
+	}
+	if !strings.HasPrefix(got.partiallyInvalid.Message, "Dropped Rule") {
+		t.Errorf("PartiallyInvalid.Message = %q, want prefix \"Dropped Rule\"", got.partiallyInvalid.Message)
+	}
+	if len(got.routes) != 2 {
+		t.Fatalf("got %d routes, want 2", len(got.routes))
+	}
+	if _, ok := got.routes[0].Action.(*routev3.Route_Route); !ok {
+		t.Errorf("the valid rule must still forward, got %T", got.routes[0].Action)
+	}
+	if _, ok := got.routes[1].Action.(*routev3.Route_DirectResponse); !ok {
+		t.Errorf("the invalid rule must fail closed, got %T", got.routes[1].Action)
 	}
 }
 

--- a/pkg/gateway/externalauth_test.go
+++ b/pkg/gateway/externalauth_test.go
@@ -1,0 +1,648 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gateway
+
+import (
+	"strings"
+	"testing"
+
+	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	extauthzv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_authz/v3"
+	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func externalAuthFilter(extAuth *gatewayv1.HTTPExternalAuthFilter) gatewayv1.HTTPRouteFilter {
+	return gatewayv1.HTTPRouteFilter{
+		Type:         gatewayv1.HTTPRouteFilterExternalAuth,
+		ExternalAuth: extAuth,
+	}
+}
+
+func httpExternalAuth(namespace, name string, port int32) *gatewayv1.HTTPExternalAuthFilter {
+	extAuth := &gatewayv1.HTTPExternalAuthFilter{
+		ExternalAuthProtocol: gatewayv1.HTTPRouteExternalAuthHTTPProtocol,
+		BackendRef: gatewayv1.BackendObjectReference{
+			Name: gatewayv1.ObjectName(name),
+			Port: ptr.To(gatewayv1.PortNumber(port)),
+		},
+	}
+	if namespace != "" {
+		extAuth.BackendRef.Namespace = ptr.To(gatewayv1.Namespace(namespace))
+	}
+	return extAuth
+}
+
+func TestResolveExternalAuthBackend(t *testing.T) {
+	svcLister := newMockServiceLister(
+		makeService("default", "authz", 9000),
+		makeService("infra", "authz", 9000),
+	)
+	noGrants := newFakeReferenceGrantLister(nil, nil)
+	grants := newFakeReferenceGrantLister([]*gatewayv1.ReferenceGrant{{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "infra", Name: "grant"},
+		Spec: gatewayv1.ReferenceGrantSpec{
+			From: []gatewayv1.ReferenceGrantFrom{{
+				Group:     gatewayv1.GroupName,
+				Kind:      "HTTPRoute",
+				Namespace: "default",
+			}},
+			To: []gatewayv1.ReferenceGrantTo{{Group: "", Kind: "Service"}},
+		},
+	}}, nil)
+
+	testCases := []struct {
+		name        string
+		extAuth     *gatewayv1.HTTPExternalAuthFilter
+		wantCluster string
+		wantReason  string
+	}{
+		{
+			name:        "same namespace service",
+			extAuth:     httpExternalAuth("", "authz", 9000),
+			wantCluster: "extauth_default_authz_core_Service_9000",
+		},
+		{
+			name:       "missing service",
+			extAuth:    httpExternalAuth("", "missing", 9000),
+			wantReason: string(gatewayv1.RouteReasonBackendNotFound),
+		},
+		{
+			name: "unsupported kind",
+			extAuth: func() *gatewayv1.HTTPExternalAuthFilter {
+				e := httpExternalAuth("", "authz", 9000)
+				e.BackendRef.Kind = ptr.To(gatewayv1.Kind("Pod"))
+				return e
+			}(),
+			wantReason: string(gatewayv1.RouteReasonInvalidKind),
+		},
+		{
+			name: "missing port",
+			extAuth: func() *gatewayv1.HTTPExternalAuthFilter {
+				e := httpExternalAuth("", "authz", 9000)
+				e.BackendRef.Port = nil
+				return e
+			}(),
+			wantReason: string(gatewayv1.RouteReasonUnsupportedProtocol),
+		},
+		{
+			name:       "cross namespace without grant",
+			extAuth:    httpExternalAuth("infra", "authz", 9000),
+			wantReason: string(gatewayv1.RouteReasonRefNotPermitted),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := resolveExternalAuthBackend("default", tc.extAuth, svcLister, noGrants)
+			if tc.wantReason != "" {
+				if err == nil {
+					t.Fatalf("expected error with reason %q, got cluster %q", tc.wantReason, got)
+				}
+				controllerErr, ok := err.(*ControllerError)
+				if !ok {
+					t.Fatalf("expected *ControllerError, got %T", err)
+				}
+				if controllerErr.Reason != tc.wantReason {
+					t.Errorf("got reason %q, want %q", controllerErr.Reason, tc.wantReason)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.wantCluster {
+				t.Errorf("got cluster %q, want %q", got, tc.wantCluster)
+			}
+		})
+	}
+
+	t.Run("cross namespace with grant", func(t *testing.T) {
+		got, err := resolveExternalAuthBackend("default", httpExternalAuth("infra", "authz", 9000), svcLister, grants)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if want := "extauth_infra_authz_core_Service_9000"; got != want {
+			t.Errorf("got cluster %q, want %q", got, want)
+		}
+	})
+}
+
+func TestBuildExtAuthzConfigHTTP(t *testing.T) {
+	extAuth := httpExternalAuth("", "authz", 9000)
+	extAuth.HTTPAuthConfig = &gatewayv1.HTTPAuthConfig{
+		Path:                   "/auth",
+		AllowedRequestHeaders:  []string{"X-Request-Id"},
+		AllowedResponseHeaders: []string{"X-User"},
+	}
+	extAuth.ForwardBody = &gatewayv1.ForwardBodyConfig{MaxSize: 1024}
+
+	got, err := buildExtAuthzConfig(extAuth, "cluster", "authz.default.svc.cluster.local:9000")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := got.Validate(); err != nil {
+		t.Fatalf("generated ext_authz config is invalid: %v", err)
+	}
+
+	httpService := got.GetHttpService()
+	if httpService == nil {
+		t.Fatal("expected an http_service to be configured")
+	}
+	if httpService.GetServerUri().GetCluster() != "cluster" {
+		t.Errorf("got cluster %q, want %q", httpService.GetServerUri().GetCluster(), "cluster")
+	}
+	if httpService.GetPathPrefix() != "/auth" {
+		t.Errorf("got path prefix %q, want %q", httpService.GetPathPrefix(), "/auth")
+	}
+	reqHeaders := httpService.GetAuthorizationRequest().GetAllowedHeaders().GetPatterns()
+	if len(reqHeaders) != 1 || reqHeaders[0].GetExact() != "X-Request-Id" {
+		t.Errorf("unexpected allowed request headers: %v", reqHeaders)
+	}
+	respHeaders := httpService.GetAuthorizationResponse().GetAllowedUpstreamHeaders().GetPatterns()
+	if len(respHeaders) != 1 || respHeaders[0].GetExact() != "X-User" {
+		t.Errorf("unexpected allowed response headers: %v", respHeaders)
+	}
+	if got.GetWithRequestBody().GetMaxRequestBytes() != 1024 {
+		t.Errorf("got max request bytes %d, want 1024", got.GetWithRequestBody().GetMaxRequestBytes())
+	}
+	if got.GetWithRequestBody().GetAllowPartialMessage() {
+		t.Error("expected allow_partial_message to be unset so oversized bodies are rejected with 413")
+	}
+	if got.GetWithRequestBody().GetPackAsBytes() {
+		t.Error("pack_as_bytes only applies to the gRPC protocol")
+	}
+	if got.GetFailureModeAllow() {
+		t.Error("requests must not be forwarded when authorization fails")
+	}
+}
+
+func TestBuildExtAuthzConfigGRPC(t *testing.T) {
+	extAuth := httpExternalAuth("", "authz", 9000)
+	extAuth.ExternalAuthProtocol = gatewayv1.HTTPRouteExternalAuthGRPCProtocol
+	extAuth.GRPCAuthConfig = &gatewayv1.GRPCAuthConfig{AllowedRequestHeaders: []string{"Authorization"}}
+	extAuth.ForwardBody = &gatewayv1.ForwardBodyConfig{MaxSize: 64}
+
+	got, err := buildExtAuthzConfig(extAuth, "cluster", "authz.default.svc.cluster.local:9000")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := got.Validate(); err != nil {
+		t.Fatalf("generated ext_authz config is invalid: %v", err)
+	}
+	if got.GetGrpcService().GetEnvoyGrpc().GetClusterName() != "cluster" {
+		t.Errorf("got cluster %q, want %q", got.GetGrpcService().GetEnvoyGrpc().GetClusterName(), "cluster")
+	}
+	patterns := got.GetAllowedHeaders().GetPatterns()
+	if len(patterns) != 1 || patterns[0].GetExact() != "Authorization" {
+		t.Errorf("unexpected allowed headers: %v", patterns)
+	}
+	if !got.GetWithRequestBody().GetPackAsBytes() {
+		t.Error("expected pack_as_bytes for the gRPC protocol")
+	}
+}
+
+func TestBuildExtAuthzConfigDefaultResponseHeaders(t *testing.T) {
+	got, err := buildExtAuthzConfig(httpExternalAuth("", "authz", 9000), "cluster", "authz:9000")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	patterns := got.GetHttpService().GetAuthorizationResponse().GetAllowedUpstreamHeaders().GetPatterns()
+	if len(patterns) != 1 || patterns[0].GetSafeRegex().GetRegex() != ".*" {
+		t.Errorf("an empty allowedResponseHeaders must copy every header, got %v", patterns)
+	}
+}
+
+func TestBuildExtAuthzConfigUnsupportedProtocol(t *testing.T) {
+	extAuth := httpExternalAuth("", "authz", 9000)
+	extAuth.ExternalAuthProtocol = "TCP"
+	if _, err := buildExtAuthzConfig(extAuth, "cluster", "authz:9000"); err == nil {
+		t.Fatal("expected an error for an unsupported protocol")
+	}
+}
+
+func TestBuildExternalAuthFilterNameIsDeterministic(t *testing.T) {
+	extAuth := httpExternalAuth("", "authz", 9000)
+
+	first, filter, err := buildExternalAuthFilter(extAuth, "cluster", "authz:9000")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.HasPrefix(first, externalAuthFilterPrefix) {
+		t.Errorf("filter name %q does not use the expected prefix", first)
+	}
+	if filter.Name != first {
+		t.Errorf("filter name %q does not match returned name %q", filter.Name, first)
+	}
+	if !filter.GetDisabled() {
+		t.Error("the ext_authz filter must be disabled so only opted-in routes use it")
+	}
+
+	second, _, err := buildExternalAuthFilter(extAuth, "cluster", "authz:9000")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if first != second {
+		t.Errorf("identical configurations produced different names: %q vs %q", first, second)
+	}
+
+	changed := httpExternalAuth("", "authz", 9000)
+	changed.HTTPAuthConfig = &gatewayv1.HTTPAuthConfig{Path: "/auth"}
+	third, _, err := buildExternalAuthFilter(changed, "cluster", "authz:9000")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if first == third {
+		t.Error("different configurations produced the same filter name")
+	}
+}
+
+func TestTranslateHTTPRouteWithExternalAuth(t *testing.T) {
+	svcLister := newMockServiceLister(makeService("default", "svc", 80), makeService("default", "authz", 9000))
+	noGrants := newFakeReferenceGrantLister(nil, nil)
+
+	extAuth := httpExternalAuth("", "authz", 9000)
+	route := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "route"},
+		Spec: gatewayv1.HTTPRouteSpec{
+			Rules: []gatewayv1.HTTPRouteRule{makeRuleWithFilters(externalAuthFilter(extAuth))},
+		},
+	}
+
+	got := translateHTTPRouteToEnvoyRoutes(route, svcLister, noGrants)
+	if got.notAccepted != nil {
+		t.Fatalf("route was rejected: %v", got.notAccepted.Message)
+	}
+	if got.resolvedRefsFailure != nil {
+		t.Fatalf("unexpected ResolvedRefs failure: %v", got.resolvedRefsFailure.Message)
+	}
+	if len(got.routes) != 1 {
+		t.Fatalf("got %d routes, want 1", len(got.routes))
+	}
+
+	wantName, _, err := buildExternalAuthFilter(extAuth, "extauth_default_authz_core_Service_9000", externalAuthAuthority("default", extAuth))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := got.externalAuth[wantName]; !ok {
+		t.Fatalf("translation did not return the resources for filter %q, got %v", wantName, got.externalAuth)
+	}
+	perFilter, ok := got.routes[0].TypedPerFilterConfig[wantName]
+	if !ok {
+		t.Fatalf("route is missing the per-filter config for %q, got %v", wantName, got.routes[0].TypedPerFilterConfig)
+	}
+	perRoute := &extauthzv3.ExtAuthzPerRoute{}
+	if err := perFilter.UnmarshalTo(perRoute); err != nil {
+		t.Fatalf("failed to unmarshal per-route config: %v", err)
+	}
+	if err := perRoute.Validate(); err != nil {
+		t.Fatalf("generated per-route config is invalid: %v", err)
+	}
+	if perRoute.GetCheckSettings() == nil {
+		t.Error("per-route config must enable the filter through check_settings")
+	}
+	if _, ok := got.routes[0].Action.(*routev3.Route_Route); !ok {
+		t.Errorf("expected a forwarding action, got %T", got.routes[0].Action)
+	}
+}
+
+func TestTranslateHTTPRouteWithUnresolvableExternalAuth(t *testing.T) {
+	svcLister := newMockServiceLister(makeService("default", "svc", 80))
+	noGrants := newFakeReferenceGrantLister(nil, nil)
+
+	route := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "route"},
+		Spec: gatewayv1.HTTPRouteSpec{
+			Rules: []gatewayv1.HTTPRouteRule{makeRuleWithFilters(externalAuthFilter(httpExternalAuth("", "missing", 9000)))},
+		},
+	}
+
+	got := translateHTTPRouteToEnvoyRoutes(route, svcLister, noGrants)
+	if got.resolvedRefsFailure == nil {
+		t.Fatal("expected a ResolvedRefs failure when the authorization server cannot be resolved")
+	}
+	if got.resolvedRefsFailure.Reason != string(gatewayv1.RouteReasonBackendNotFound) {
+		t.Errorf("got reason %q, want %q", got.resolvedRefsFailure.Reason, gatewayv1.RouteReasonBackendNotFound)
+	}
+	if len(got.routes) != 1 {
+		t.Fatalf("got %d routes, want 1", len(got.routes))
+	}
+	direct, ok := got.routes[0].Action.(*routev3.Route_DirectResponse)
+	if !ok {
+		t.Fatalf("expected the request to fail closed, got %T", got.routes[0].Action)
+	}
+	if direct.DirectResponse.Status != 500 {
+		t.Errorf("got status %d, want 500", direct.DirectResponse.Status)
+	}
+	if len(got.routes[0].TypedPerFilterConfig) != 0 {
+		t.Error("no per-filter config may reference a filter that was not installed")
+	}
+	if len(got.externalAuth) != 0 {
+		t.Error("no Envoy resources may be produced for an unresolvable authorization server")
+	}
+}
+
+func TestExternalAuthFilterIsSupported(t *testing.T) {
+	filters := []gatewayv1.HTTPRouteFilter{externalAuthFilter(httpExternalAuth("", "authz", 9000))}
+	if unsupported, found := findUnsupportedFilter(filters); found {
+		t.Errorf("ExternalAuth must be a supported filter, got %q reported as unsupported", unsupported)
+	}
+}
+
+func TestListenerFilterChainIncludesExternalAuth(t *testing.T) {
+	_, extAuthFilter, err := buildExternalAuthFilter(httpExternalAuth("", "authz", 9000), "cluster", "authz:9000")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	c := &Controller{}
+	lis := gatewayv1.Listener{Name: "http", Protocol: gatewayv1.HTTPProtocolType, Port: 80}
+	filterChain, err := c.translateListenerToFilterChain(&gatewayv1.Gateway{}, lis, nil, "route-80", []*hcm.HttpFilter{extAuthFilter})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	manager := &hcm.HttpConnectionManager{}
+	if err := filterChain.Filters[0].GetTypedConfig().UnmarshalTo(manager); err != nil {
+		t.Fatalf("failed to unmarshal the connection manager: %v", err)
+	}
+	if err := manager.Validate(); err != nil {
+		t.Fatalf("generated connection manager is invalid: %v", err)
+	}
+	if len(manager.HttpFilters) != 2 {
+		t.Fatalf("got %d http filters, want 2", len(manager.HttpFilters))
+	}
+	if manager.HttpFilters[0].Name != extAuthFilter.Name {
+		t.Errorf("the authorization filter must run before the router, got %q first", manager.HttpFilters[0].Name)
+	}
+	if manager.HttpFilters[1].Name != wellknown.Router {
+		t.Errorf("the router must be the last filter, got %q", manager.HttpFilters[1].Name)
+	}
+}
+
+func routeWithExternalAuth(namespace, name string, extAuths ...*gatewayv1.HTTPExternalAuthFilter) *gatewayv1.HTTPRoute {
+	filters := make([]gatewayv1.HTTPRouteFilter, 0, len(extAuths))
+	for _, extAuth := range extAuths {
+		filters = append(filters, externalAuthFilter(extAuth))
+	}
+	return &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+		Spec: gatewayv1.HTTPRouteSpec{
+			Rules: []gatewayv1.HTTPRouteRule{makeRuleWithFilters(filters...)},
+		},
+	}
+}
+
+// makeAuthService builds an authorization Service with a ClusterIP, which the
+// Envoy cluster needs to resolve to a valid endpoint address.
+func makeAuthService(namespace, name string, port int32, clusterIP string) *corev1.Service {
+	svc := makeService(namespace, name, port)
+	svc.Spec.ClusterIP = clusterIP
+	return svc
+}
+
+func TestResolveRuleExternalAuth(t *testing.T) {
+	svcLister := newMockServiceLister(
+		makeService("default", "svc", 80),
+		makeAuthService("default", "authz", 9000, "10.0.0.10"),
+		makeAuthService("default", "authz-grpc", 9001, "10.0.0.11"),
+	)
+	noGrants := newFakeReferenceGrantLister(nil, nil)
+
+	grpcAuth := httpExternalAuth("", "authz-grpc", 9001)
+	grpcAuth.ExternalAuthProtocol = gatewayv1.HTTPRouteExternalAuthGRPCProtocol
+	pathAuth := httpExternalAuth("", "authz", 9000)
+	pathAuth.HTTPAuthConfig = &gatewayv1.HTTPAuthConfig{Path: "/auth"}
+
+	// The same configuration listed twice must collapse into one filter.
+	filters := []gatewayv1.HTTPRouteFilter{
+		externalAuthFilter(httpExternalAuth("", "authz", 9000)),
+		externalAuthFilter(httpExternalAuth("", "authz", 9000)),
+		externalAuthFilter(pathAuth),
+		externalAuthFilter(grpcAuth),
+	}
+
+	got, err := resolveRuleExternalAuth("default", filters, svcLister, noGrants)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("got %d ext_authz filters, want 3", len(got))
+	}
+
+	for name, resources := range got {
+		if resources.httpFilter.Name != name {
+			t.Errorf("filter %q is keyed under %q", resources.httpFilter.Name, name)
+		}
+		if err := resources.cluster.Validate(); err != nil {
+			t.Errorf("cluster %q is invalid: %v", resources.cluster.Name, err)
+		}
+	}
+
+	grpcName, _, err := buildExternalAuthFilter(grpcAuth, "extauth_default_authz-grpc_core_Service_9001", externalAuthAuthority("default", grpcAuth))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	grpcCluster := got[grpcName].cluster
+	if grpcCluster.Name != "extauth_default_authz-grpc_core_Service_9001" {
+		t.Errorf("got cluster name %q", grpcCluster.Name)
+	}
+	if _, ok := grpcCluster.TypedExtensionProtocolOptions["envoy.extensions.upstreams.http.v3.HttpProtocolOptions"]; !ok {
+		t.Error("a gRPC authorization server requires an HTTP/2 upstream")
+	}
+
+	httpName, _, err := buildExternalAuthFilter(httpExternalAuth("", "authz", 9000), "extauth_default_authz_core_Service_9000", "authz.default.svc.cluster.local:9000")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got[httpName].cluster.TypedExtensionProtocolOptions) != 0 {
+		t.Error("an HTTP authorization server must not be forced to HTTP/2")
+	}
+}
+
+// Resolution is all or nothing: one bad reference must not leave the rule with a
+// partially applied authorization chain.
+func TestResolveRuleExternalAuthIsAllOrNothing(t *testing.T) {
+	svcLister := newMockServiceLister(makeAuthService("default", "authz", 9000, "10.0.0.10"))
+	noGrants := newFakeReferenceGrantLister(nil, nil)
+
+	got, err := resolveRuleExternalAuth("default", []gatewayv1.HTTPRouteFilter{
+		externalAuthFilter(httpExternalAuth("", "authz", 9000)),
+		externalAuthFilter(httpExternalAuth("", "missing", 9000)),
+	}, svcLister, noGrants)
+	if err == nil {
+		t.Fatal("expected an error when one authorization server cannot be resolved")
+	}
+	if got != nil {
+		t.Errorf("no resources may be returned on failure, got %v", got)
+	}
+}
+
+// Envoy rejects a route configuration that references an HTTP filter which is
+// not installed on the connection manager, so every filter a route enables must
+// come back in the same translation result.
+func TestExternalAuthRoutesOnlyReferenceReturnedFilters(t *testing.T) {
+	svcLister := newMockServiceLister(
+		makeService("default", "svc", 80),
+		makeAuthService("default", "authz", 9000, "10.0.0.10"),
+		makeAuthService("infra", "authz", 9000, "10.0.0.12"),
+	)
+	grants := newFakeReferenceGrantLister([]*gatewayv1.ReferenceGrant{{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "infra", Name: "grant"},
+		Spec: gatewayv1.ReferenceGrantSpec{
+			From: []gatewayv1.ReferenceGrantFrom{{
+				Group:     gatewayv1.GroupName,
+				Kind:      "HTTPRoute",
+				Namespace: "default",
+			}},
+			To: []gatewayv1.ReferenceGrantTo{{Group: "", Kind: "Service"}},
+		},
+	}}, nil)
+
+	grpcAuth := httpExternalAuth("", "authz", 9000)
+	grpcAuth.ExternalAuthProtocol = gatewayv1.HTTPRouteExternalAuthGRPCProtocol
+	bodyAuth := httpExternalAuth("", "authz", 9000)
+	bodyAuth.ForwardBody = &gatewayv1.ForwardBodyConfig{MaxSize: 512}
+
+	routes := []*gatewayv1.HTTPRoute{
+		routeWithExternalAuth("default", "plain", httpExternalAuth("", "authz", 9000)),
+		routeWithExternalAuth("default", "grpc", grpcAuth),
+		routeWithExternalAuth("default", "body", bodyAuth),
+		routeWithExternalAuth("default", "cross-ns", httpExternalAuth("infra", "authz", 9000)),
+		routeWithExternalAuth("default", "unresolvable", httpExternalAuth("", "missing", 9000)),
+		// A rule may chain more than one authorization server.
+		routeWithExternalAuth("default", "chained", httpExternalAuth("", "authz", 9000), grpcAuth),
+	}
+
+	for _, route := range routes {
+		got := translateHTTPRouteToEnvoyRoutes(route, svcLister, grants)
+		for _, envoyRoute := range got.routes {
+			for name := range envoyRoute.TypedPerFilterConfig {
+				if _, ok := got.externalAuth[name]; !ok {
+					t.Errorf("route %s/%s references filter %q which was not returned", route.Namespace, route.Name, name)
+				}
+			}
+		}
+	}
+
+	chained := translateHTTPRouteToEnvoyRoutes(routes[5], svcLister, grants)
+	if len(chained.routes[0].TypedPerFilterConfig) != 2 {
+		t.Errorf("got %d enabled filters for the chained rule, want 2", len(chained.routes[0].TypedPerFilterConfig))
+	}
+	if len(chained.externalAuth) != 2 {
+		t.Errorf("got %d returned filters for the chained rule, want 2", len(chained.externalAuth))
+	}
+}
+
+// A rule whose authorization server is unresolvable must keep matching its own
+// traffic, otherwise requests fall through to a lower precedence route that has
+// no authorization at all.
+func TestUnresolvableExternalAuthShadowsLowerPrecedenceRules(t *testing.T) {
+	svcLister := newMockServiceLister(makeService("default", "svc", 80))
+	noGrants := newFakeReferenceGrantLister(nil, nil)
+
+	secure := makeRuleWithFilters(externalAuthFilter(httpExternalAuth("", "missing", 9000)))
+	secure.Matches = []gatewayv1.HTTPRouteMatch{{
+		Path: &gatewayv1.HTTPPathMatch{
+			Type:  ptr.To(gatewayv1.PathMatchPathPrefix),
+			Value: ptr.To("/secure"),
+		},
+	}}
+
+	route := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "route"},
+		Spec: gatewayv1.HTTPRouteSpec{
+			Rules: []gatewayv1.HTTPRouteRule{secure, makeRuleWithBackend("svc")},
+		},
+	}
+
+	got := translateHTTPRouteToEnvoyRoutes(route, svcLister, noGrants)
+	if len(got.routes) != 2 {
+		t.Fatalf("got %d routes, want 2: the broken rule must still claim its matches", len(got.routes))
+	}
+	if got.routes[0].Match.GetPathSeparatedPrefix() != "/secure" {
+		t.Errorf("first route does not match /secure: %v", got.routes[0].Match)
+	}
+	if _, ok := got.routes[0].Action.(*routev3.Route_DirectResponse); !ok {
+		t.Errorf("the unauthorized rule must answer directly, got %T", got.routes[0].Action)
+	}
+	// The healthy rule is untouched.
+	if _, ok := got.routes[1].Action.(*routev3.Route_Route); !ok {
+		t.Errorf("the healthy rule must still forward, got %T", got.routes[1].Action)
+	}
+}
+
+func TestExternalAuthAcrossMultipleRules(t *testing.T) {
+	svcLister := newMockServiceLister(
+		makeService("default", "svc", 80),
+		makeAuthService("default", "authz", 9000, "10.0.0.10"),
+		makeAuthService("default", "authz-b", 9001, "10.0.0.11"),
+	)
+	noGrants := newFakeReferenceGrantLister(nil, nil)
+
+	route := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "route"},
+		Spec: gatewayv1.HTTPRouteSpec{
+			Rules: []gatewayv1.HTTPRouteRule{
+				makeRuleWithFilters(externalAuthFilter(httpExternalAuth("", "authz", 9000))),
+				makeRuleWithFilters(externalAuthFilter(httpExternalAuth("", "authz-b", 9001))),
+				makeRuleWithFilters(),
+			},
+		},
+	}
+
+	got := translateHTTPRouteToEnvoyRoutes(route, svcLister, noGrants)
+	if got.resolvedRefsFailure != nil {
+		t.Fatalf("unexpected ResolvedRefs failure: %v", got.resolvedRefsFailure.Message)
+	}
+	if len(got.externalAuth) != 2 {
+		t.Fatalf("got %d filters for the route, want 2", len(got.externalAuth))
+	}
+	if len(got.routes) != 3 {
+		t.Fatalf("got %d routes, want 3", len(got.routes))
+	}
+	for i, want := range []int{1, 1, 0} {
+		if len(got.routes[i].TypedPerFilterConfig) != want {
+			t.Errorf("route %d enables %d filters, want %d", i, len(got.routes[i].TypedPerFilterConfig), want)
+		}
+	}
+	// Each rule must enable only its own authorization server.
+	for name := range got.routes[0].TypedPerFilterConfig {
+		if _, ok := got.routes[1].TypedPerFilterConfig[name]; ok {
+			t.Errorf("filter %q leaked from rule 0 into rule 1", name)
+		}
+	}
+}
+
+func TestResolveRuleExternalAuthCrossNamespaceRequiresGrant(t *testing.T) {
+	svcLister := newMockServiceLister(makeAuthService("infra", "authz", 9000, "10.0.0.12"))
+
+	got, err := resolveRuleExternalAuth("default", []gatewayv1.HTTPRouteFilter{
+		externalAuthFilter(httpExternalAuth("infra", "authz", 9000)),
+	}, svcLister, newFakeReferenceGrantLister(nil, nil))
+	if err == nil {
+		t.Fatal("a cross-namespace reference without a ReferenceGrant must be rejected")
+	}
+	if got != nil {
+		t.Errorf("no resources may be programmed, got %v", got)
+	}
+}

--- a/pkg/gateway/features.go
+++ b/pkg/gateway/features.go
@@ -21,11 +21,13 @@ import (
 
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/gateway-api/pkg/features"
+
+	"sigs.k8s.io/cloud-provider-kind/pkg/config"
 )
 
-// supportedFeatures is the sorted list of Gateway API features that
-// cloud-provider-kind supports, as defined by GEP-2162.
-var supportedFeatures = buildSupportedFeatures(
+// standardFeatureNames are the Gateway API features supported by
+// cloud-provider-kind in every release channel.
+var standardFeatureNames = []features.FeatureName{
 	// Core
 	features.SupportGateway,
 	features.SupportHTTPRoute,
@@ -40,7 +42,34 @@ var supportedFeatures = buildSupportedFeatures(
 	features.SupportHTTPRouteBackendProtocolWebSocket,
 	features.SupportHTTPRouteParentRefPort,
 	features.SupportHTTPRouteQueryParamMatching,
-)
+}
+
+// experimentalFeatureNames are only advertised when the experimental CRDs are
+// installed, since the corresponding API fields do not exist otherwise.
+// GEP-1494 (HTTP Auth) is still experimental, so the feature names are not yet
+// published as constants by sigs.k8s.io/gateway-api/pkg/features.
+var experimentalFeatureNames = []features.FeatureName{
+	"HTTPRouteExternalAuth",
+	"HTTPRouteExternalAuthForwardBody",
+	"HTTPRouteExternalAuthGRPC",
+	"HTTPRouteExternalAuthHTTP",
+}
+
+// supportedFeatures is the sorted list of Gateway API features that
+// cloud-provider-kind supports, as defined by GEP-2162.
+var supportedFeatures = buildSupportedFeatures(standardFeatureNames...)
+
+// supportedFeaturesForChannel returns the features to advertise on the
+// GatewayClass status for the Gateway API release channel in use.
+func supportedFeaturesForChannel(channel config.GatewayReleaseChannel) []gatewayv1.SupportedFeature {
+	if channel != config.Experimental {
+		return supportedFeatures
+	}
+	names := make([]features.FeatureName, 0, len(standardFeatureNames)+len(experimentalFeatureNames))
+	names = append(names, standardFeatureNames...)
+	names = append(names, experimentalFeatureNames...)
+	return buildSupportedFeatures(names...)
+}
 
 // The spec requires features to be sorted in ascending alphabetical order.
 func buildSupportedFeatures(names ...features.FeatureName) []gatewayv1.SupportedFeature {

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -15,6 +15,7 @@ import (
 	endpointv3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	listenerv3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	typev3 "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	envoyproxytypes "github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	cachev3 "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
@@ -29,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
+	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
@@ -200,11 +202,15 @@ func (c *Controller) buildEnvoyResourcesForGateway(gateway *gatewayv1.Gateway) (
 	finalEnvoyListeners := []envoyproxytypes.Resource{}
 	// Process Listeners by Port
 	for port, listeners := range listenersByPort {
-		// This slice will hold the filter chains.
-		var filterChains []*listenerv3.FilterChain
 		// Prepare to collect ALL virtual hosts for this port into a single list.
 		virtualHostsForPort := make(map[string]*routev3.VirtualHost)
 		routeName := fmt.Sprintf("route-%d", port)
+		// All listeners on a port share one route configuration, so an HTTP
+		// filter needed by any of their routes has to be installed on every
+		// filter chain of the port. Filter chains are therefore only built once
+		// every route on the port has been translated.
+		extraHTTPFilters := make(map[string]*hcm.HttpFilter)
+		var listenersToProgram []gatewayv1.Listener
 
 		// All these listeners have the same port
 		for _, listener := range listeners {
@@ -267,30 +273,30 @@ func (c *Controller) buildEnvoyResourcesForGateway(gateway *gatewayv1.Gateway) (
 				// Process HTTPRoutes
 				// Get the routes that were pre-validated for this specific listener.
 				for _, httpRoute := range routesByListener[listener.Name] {
-					routes, validBackendRefs, notAccepted, resolvedRefsFailure, partiallyInvalidCond := translateHTTPRouteToEnvoyRoutes(httpRoute, c.serviceLister, c.referenceGrantLister)
+					translation := translateHTTPRouteToEnvoyRoutes(httpRoute, c.serviceLister, c.referenceGrantLister)
 
 					key := types.NamespacedName{Name: httpRoute.Name, Namespace: httpRoute.Namespace}
 					currentParentStatuses := httpRouteStatuses[key]
 					for i := range currentParentStatuses {
-						if notAccepted != nil {
-							meta.SetStatusCondition(&currentParentStatuses[i].Conditions, *notAccepted)
+						if translation.notAccepted != nil {
+							meta.SetStatusCondition(&currentParentStatuses[i].Conditions, *translation.notAccepted)
 						}
 						if meta.IsStatusConditionTrue(currentParentStatuses[i].Conditions, string(gatewayv1.RouteConditionAccepted)) {
-							if resolvedRefsFailure != nil {
-								meta.SetStatusCondition(&currentParentStatuses[i].Conditions, *resolvedRefsFailure)
+							if translation.resolvedRefsFailure != nil {
+								meta.SetStatusCondition(&currentParentStatuses[i].Conditions, *translation.resolvedRefsFailure)
 							} else {
 								meta.SetStatusCondition(&currentParentStatuses[i].Conditions, createResolvedCondition(httpRoute.Generation))
 							}
-							if partiallyInvalidCond != nil {
-								meta.SetStatusCondition(&currentParentStatuses[i].Conditions, *partiallyInvalidCond)
+							if translation.partiallyInvalid != nil {
+								meta.SetStatusCondition(&currentParentStatuses[i].Conditions, *translation.partiallyInvalid)
 							}
 						}
 					}
 					httpRouteStatuses[key] = currentParentStatuses
 
 					// Create the necessary Envoy Cluster resources from the valid backends.
-					for _, backendRef := range validBackendRefs {
-						cluster, err := c.translateBackendRefToCluster(httpRoute.Namespace, backendRef)
+					for _, backendRef := range translation.backendRefs {
+						cluster, err := translateBackendRefToCluster(c.serviceLister, httpRoute.Namespace, backendRef)
 						if err == nil && cluster != nil {
 							if _, exists := envoyClusters[cluster.Name]; !exists {
 								envoyClusters[cluster.Name] = cluster
@@ -298,8 +304,17 @@ func (c *Controller) buildEnvoyResourcesForGateway(gateway *gatewayv1.Gateway) (
 						}
 					}
 
+					// Resources the translated routes reference through their
+					// typed_per_filter_config, such as GEP-1494 authorization servers.
+					for name, resources := range translation.externalAuth {
+						extraHTTPFilters[name] = resources.httpFilter
+						if _, exists := envoyClusters[resources.cluster.Name]; !exists {
+							envoyClusters[resources.cluster.Name] = resources.cluster
+						}
+					}
+
 					// Aggregate Envoy routes into VirtualHosts.
-					if routes != nil {
+					if translation.routes != nil {
 						attachedRoutes++
 						// Get the domain for this listener's VirtualHost.
 						vhostDomains := getIntersectingHostnames(listener, httpRoute.Spec.Hostnames)
@@ -312,11 +327,11 @@ func (c *Controller) buildEnvoyResourcesForGateway(gateway *gatewayv1.Gateway) (
 								}
 								virtualHostsForPort[domain] = vh
 							}
-							vh.Routes = append(vh.Routes, routes...)
+							vh.Routes = append(vh.Routes, translation.routes...)
 							klog.V(4).Infof("created VirtualHost %s for listener %s with domain %s", vh.Name, listener.
 								Name, domain)
 							if klog.V(4).Enabled() {
-								for _, route := range routes {
+								for _, route := range translation.routes {
 									klog.Infof("adding route %s to VirtualHost %s", route.Name, vh.Name)
 								}
 							}
@@ -338,12 +353,37 @@ func (c *Controller) buildEnvoyResourcesForGateway(gateway *gatewayv1.Gateway) (
 				continue
 			}
 
-			vhSlice := make([]*routev3.VirtualHost, 0, len(virtualHostsForPort))
-			for _, vh := range virtualHostsForPort {
-				vhSlice = append(vhSlice, vh)
-			}
+			listenerStatus.AttachedRoutes = attachedRoutes
+			meta.SetStatusCondition(&listenerStatus.Conditions, metav1.Condition{
+				Type:               string(gatewayv1.ListenerConditionAccepted),
+				Status:             metav1.ConditionTrue,
+				Reason:             string(gatewayv1.ListenerReasonAccepted),
+				Message:            "Listener is valid",
+				ObservedGeneration: gateway.Generation,
+			})
+			allListenerStatuses[listener.Name] = listenerStatus
+			listenersToProgram = append(listenersToProgram, listener)
+		}
 
-			filterChain, err := c.translateListenerToFilterChain(gateway, listener, vhSlice, routeName)
+		allVirtualHosts := make([]*routev3.VirtualHost, 0, len(virtualHostsForPort))
+		for _, vh := range virtualHostsForPort {
+			sortRoutes(vh.Routes)
+			allVirtualHosts = append(allVirtualHosts, vh)
+		}
+
+		// now aggregate all the listeners on the same port
+		routeConfig := &routev3.RouteConfiguration{
+			Name:                     routeName,
+			VirtualHosts:             allVirtualHosts,
+			IgnorePortInHostMatching: true, // tricky to figure out thanks to howardjohn
+		}
+		envoyRoutes = append(envoyRoutes, routeConfig)
+
+		httpFilters := sortedHTTPFilters(extraHTTPFilters)
+		var filterChains []*listenerv3.FilterChain
+		for _, listener := range listenersToProgram {
+			listenerStatus := allListenerStatuses[listener.Name]
+			filterChain, err := c.translateListenerToFilterChain(gateway, listener, allVirtualHosts, routeName, httpFilters)
 			if err != nil {
 				meta.SetStatusCondition(&listenerStatus.Conditions, metav1.Condition{
 					Type:               string(gatewayv1.ListenerConditionProgrammed),
@@ -363,31 +403,8 @@ func (c *Controller) buildEnvoyResourcesForGateway(gateway *gatewayv1.Gateway) (
 
 				filterChains = append(filterChains, filterChain)
 			}
-
-			listenerStatus.AttachedRoutes = attachedRoutes
-			meta.SetStatusCondition(&listenerStatus.Conditions, metav1.Condition{
-				Type:               string(gatewayv1.ListenerConditionAccepted),
-				Status:             metav1.ConditionTrue,
-				Reason:             string(gatewayv1.ListenerReasonAccepted),
-				Message:            "Listener is valid",
-				ObservedGeneration: gateway.Generation,
-			})
 			allListenerStatuses[listener.Name] = listenerStatus
 		}
-
-		allVirtualHosts := make([]*routev3.VirtualHost, 0, len(virtualHostsForPort))
-		for _, vh := range virtualHostsForPort {
-			sortRoutes(vh.Routes)
-			allVirtualHosts = append(allVirtualHosts, vh)
-		}
-
-		// now aggregate all the listeners on the same port
-		routeConfig := &routev3.RouteConfiguration{
-			Name:                     routeName,
-			VirtualHosts:             allVirtualHosts,
-			IgnorePortInHostMatching: true, // tricky to figure out thanks to howardjohn
-		}
-		envoyRoutes = append(envoyRoutes, routeConfig)
 
 		if len(filterChains) > 0 {
 			envoyListener := &listenerv3.Listener{
@@ -401,7 +418,7 @@ func (c *Controller) buildEnvoyResourcesForGateway(gateway *gatewayv1.Gateway) (
 			// For HTTPS, we create one filter chain per listener because they have unique
 			// SNI matches and TLS settings.
 			if listeners[0].Protocol == gatewayv1.HTTPProtocolType {
-				filterChain, _ := c.translateListenerToFilterChain(gateway, listeners[0], allVirtualHosts, routeName)
+				filterChain, _ := c.translateListenerToFilterChain(gateway, listeners[0], allVirtualHosts, routeName, httpFilters)
 				envoyListener.FilterChains = []*listenerv3.FilterChain{filterChain}
 			}
 			finalEnvoyListeners = append(finalEnvoyListeners, envoyListener)
@@ -671,12 +688,12 @@ func ruleHasRedirectFilter(rule gatewayv1.HTTPRouteRule) bool {
 	return false
 }
 
-func (c *Controller) translateBackendRefToCluster(defaultNamespace string, backendRef gatewayv1.BackendRef) (*clusterv3.Cluster, error) {
+func translateBackendRefToCluster(serviceLister corev1listers.ServiceLister, defaultNamespace string, backendRef gatewayv1.BackendRef) (*clusterv3.Cluster, error) {
 	ns := defaultNamespace
 	if backendRef.Namespace != nil {
 		ns = string(*backendRef.Namespace)
 	}
-	service, err := c.serviceLister.Services(ns).Get(string(backendRef.Name))
+	service, err := serviceLister.Services(ns).Get(string(backendRef.Name))
 	if err != nil {
 		return nil, fmt.Errorf("could not find service %s/%s: %w", ns, backendRef.Name, err)
 	}

--- a/pkg/gateway/httproute.go
+++ b/pkg/gateway/httproute.go
@@ -75,6 +75,8 @@ func translateHTTPRouteToEnvoyRoutes(
 ) routeTranslationResult {
 	var result routeTranslationResult
 	var droppedRuleMessages []string
+	var invalidExtAuthMessages []string
+	validRules := 0
 
 	for ruleIndex, rule := range httpRoute.Spec.Rules {
 		if unsupportedType, found := findUnsupportedFilter(rule.Filters); found {
@@ -104,6 +106,8 @@ func translateHTTPRouteToEnvoyRoutes(
 			}
 			cond := createNotResolvedCondition(reason, extAuthErr.Error(), httpRoute.Generation)
 			result.resolvedRefsFailure = &cond
+			invalidExtAuthMessages = append(invalidExtAuthMessages,
+				fmt.Sprintf("rule[%d]: %s", ruleIndex, extAuthErr.Error()))
 
 			// The rule still claims its matches, otherwise the request would
 			// fall through to a lower precedence route that has no authorization.
@@ -118,6 +122,7 @@ func translateHTTPRouteToEnvoyRoutes(
 			}
 			continue
 		}
+		validRules++
 
 		var extAuthPerRoute map[string]*anypb.Any
 		if len(extAuth) > 0 {
@@ -245,6 +250,12 @@ func translateHTTPRouteToEnvoyRoutes(
 
 	if len(droppedRuleMessages) > 0 {
 		msg := fmt.Sprintf("Dropped Rule(s): %s", strings.Join(droppedRuleMessages, "; "))
+		cond := createPartiallyInvalidCondition(msg, httpRoute.Generation)
+		result.partiallyInvalid = &cond
+	} else if len(invalidExtAuthMessages) > 0 && validRules > 0 {
+		// Some rules resolved and some did not: the route is still Accepted, but
+		// the invalid ExternalAuth rules must be reported as PartiallyInvalid.
+		msg := fmt.Sprintf("Dropped Rule(s): %s", strings.Join(invalidExtAuthMessages, "; "))
 		cond := createPartiallyInvalidCondition(msg, httpRoute.Generation)
 		result.partiallyInvalid = &cond
 	}

--- a/pkg/gateway/httproute.go
+++ b/pkg/gateway/httproute.go
@@ -9,6 +9,7 @@ import (
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	matcherv3 "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
+	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -25,24 +26,54 @@ func (e *noEffectiveBackendsError) Error() string {
 	return "no effective backends: backendRefs is empty or all weights are zero"
 }
 
-// translateHTTPRouteToEnvoyRoutes translates a full HTTPRoute into a slice of Envoy Routes.
-// It returns the translated routes, the valid backend refs, and up to three conditions:
-//   - notAccepted: non-nil (Accepted=False) when the entire route is rejected
-//   - resolvedRefsFailure: non-nil (ResolvedRefs=False) only when a backend ref could not be resolved;
-//     nil signals success and the caller is responsible for setting ResolvedRefs=True
-//   - partiallyInvalid: non-nil (PartiallyInvalid=True) when some rules were dropped
+// directResponse makes a rule answer by itself instead of forwarding, so a rule
+// that cannot be programmed still shadows lower precedence routes.
+func directResponse(status uint32) *routev3.Route_DirectResponse {
+	return &routev3.Route_DirectResponse{
+		DirectResponse: &routev3.DirectResponseAction{Status: status},
+	}
+}
+
+// newEnvoyRoute builds the name and match of an Envoy route. It returns a nil
+// route and the reason to report when the match cannot be translated.
+func newEnvoyRoute(httpRoute *gatewayv1.HTTPRoute, ruleIndex, matchIndex int, match gatewayv1.HTTPRouteMatch) (*routev3.Route, string) {
+	routeMatch, dropReason := translateHTTPRouteMatch(match, httpRoute.Generation)
+	if dropReason != nil {
+		return nil, fmt.Sprintf("rule[%d] match[%d]: %s", ruleIndex, matchIndex, *dropReason)
+	}
+	return &routev3.Route{
+		Name:  fmt.Sprintf("%s-%s-rule%d-match%d", httpRoute.Namespace, httpRoute.Name, ruleIndex, matchIndex),
+		Match: routeMatch,
+	}, ""
+}
+
+// routeTranslationResult is everything a translated HTTPRoute contributes to the
+// Envoy configuration, together with the conditions to report on its status.
+type routeTranslationResult struct {
+	routes      []*routev3.Route
+	backendRefs []gatewayv1.BackendRef
+	// externalAuth is keyed by the Envoy HTTP filter name that the routes
+	// reference in their typed_per_filter_config. Callers must install every
+	// entry on the connection manager or Envoy rejects the route configuration.
+	externalAuth map[string]*externalAuthResources
+
+	// notAccepted is set (Accepted=False) when the entire route is rejected.
+	notAccepted *metav1.Condition
+	// resolvedRefsFailure is set (ResolvedRefs=False) only when a reference could
+	// not be resolved; nil means the caller must set ResolvedRefs=True.
+	resolvedRefsFailure *metav1.Condition
+	// partiallyInvalid is set (PartiallyInvalid=True) when some rules were dropped.
+	partiallyInvalid *metav1.Condition
+}
+
+// translateHTTPRouteToEnvoyRoutes translates a full HTTPRoute into Envoy routes
+// and the extra resources those routes depend on.
 func translateHTTPRouteToEnvoyRoutes(
 	httpRoute *gatewayv1.HTTPRoute,
 	serviceLister corev1listers.ServiceLister,
 	referenceGrantLister gatewaylistersv1.ReferenceGrantLister,
-) (
-	envoyRoutes []*routev3.Route,
-	allValidBackendRefs []gatewayv1.BackendRef,
-	notAccepted *metav1.Condition,
-	resolvedRefsFailure *metav1.Condition,
-	partiallyInvalid *metav1.Condition,
-) {
-
+) routeTranslationResult {
+	var result routeTranslationResult
 	var droppedRuleMessages []string
 
 	for ruleIndex, rule := range httpRoute.Spec.Rules {
@@ -55,6 +86,51 @@ func translateHTTPRouteToEnvoyRoutes(
 		var redirectAction *routev3.RedirectAction
 		var headersToAdd []*corev3.HeaderValueOption
 		var headersToRemove []string
+
+		matches := rule.Matches
+		if len(matches) == 0 {
+			// A rule without matches matches everything.
+			matches = []gatewayv1.HTTPRouteMatch{{}}
+		}
+
+		// GEP-1494: the authorization server has to be resolved before anything
+		// else, because a rule that cannot be authorized must not be programmed.
+		extAuth, extAuthErr := resolveRuleExternalAuth(httpRoute.Namespace, rule.Filters, serviceLister, referenceGrantLister)
+		if extAuthErr != nil {
+			var controllerErr *ControllerError
+			reason := gatewayv1.RouteReasonBackendNotFound
+			if errors.As(extAuthErr, &controllerErr) {
+				reason = gatewayv1.RouteConditionReason(controllerErr.Reason)
+			}
+			cond := createNotResolvedCondition(reason, extAuthErr.Error(), httpRoute.Generation)
+			result.resolvedRefsFailure = &cond
+
+			// The rule still claims its matches, otherwise the request would
+			// fall through to a lower precedence route that has no authorization.
+			for matchIndex, match := range matches {
+				envoyRoute, dropped := newEnvoyRoute(httpRoute, ruleIndex, matchIndex, match)
+				if envoyRoute == nil {
+					droppedRuleMessages = append(droppedRuleMessages, dropped)
+					continue
+				}
+				envoyRoute.Action = directResponse(500)
+				result.routes = append(result.routes, envoyRoute)
+			}
+			continue
+		}
+
+		var extAuthPerRoute map[string]*anypb.Any
+		if len(extAuth) > 0 {
+			extAuthPerRoute = make(map[string]*anypb.Any, len(extAuth))
+			if result.externalAuth == nil {
+				result.externalAuth = make(map[string]*externalAuthResources)
+			}
+			for name, resources := range extAuth {
+				result.externalAuth[name] = resources
+				extAuthPerRoute[name] = enableExtAuthzPerRoute
+			}
+		}
+
 		for _, filter := range rule.Filters {
 			if filter.Type == gatewayv1.HTTPRouteFilterRequestRedirect && filter.RequestRedirect != nil {
 				redirect := filter.RequestRedirect
@@ -118,20 +194,15 @@ func translateHTTPRouteToEnvoyRoutes(
 			}
 		}
 
-		buildRoutesForRule := func(match gatewayv1.HTTPRouteMatch, matchIndex int) {
-			routeMatch, dropReason := translateHTTPRouteMatch(match, httpRoute.Generation)
-			if dropReason != nil {
-				droppedRuleMessages = append(droppedRuleMessages,
-					fmt.Sprintf("rule[%d] match[%d]: %s", ruleIndex, matchIndex, *dropReason))
-				return
+		for matchIndex, match := range matches {
+			envoyRoute, dropped := newEnvoyRoute(httpRoute, ruleIndex, matchIndex, match)
+			if envoyRoute == nil {
+				droppedRuleMessages = append(droppedRuleMessages, dropped)
+				continue
 			}
-
-			envoyRoute := &routev3.Route{
-				Name:                   fmt.Sprintf("%s-%s-rule%d-match%d", httpRoute.Namespace, httpRoute.Name, ruleIndex, matchIndex),
-				Match:                  routeMatch,
-				RequestHeadersToAdd:    headersToAdd,
-				RequestHeadersToRemove: headersToRemove,
-			}
+			envoyRoute.RequestHeadersToAdd = headersToAdd
+			envoyRoute.RequestHeadersToRemove = headersToRemove
+			envoyRoute.TypedPerFilterConfig = extAuthPerRoute
 
 			if redirectAction != nil {
 				// If this is a redirect, set the Redirect action. No backends are needed.
@@ -150,47 +221,34 @@ func translateHTTPRouteToEnvoyRoutes(
 				var noBackendsErr *noEffectiveBackendsError
 				switch {
 				case errors.As(err, &noBackendsErr):
-					envoyRoute.Action = &routev3.Route_DirectResponse{
-						DirectResponse: &routev3.DirectResponseAction{Status: 500},
-					}
+					envoyRoute.Action = directResponse(500)
 				case errors.As(err, &controllerErr):
 					cond := createNotResolvedCondition(gatewayv1.RouteConditionReason(controllerErr.Reason), controllerErr.Message, httpRoute.Generation)
-					resolvedRefsFailure = &cond
-					envoyRoute.Action = &routev3.Route_DirectResponse{
-						DirectResponse: &routev3.DirectResponseAction{Status: 500},
-					}
+					result.resolvedRefsFailure = &cond
+					envoyRoute.Action = directResponse(500)
 				default:
-					allValidBackendRefs = append(allValidBackendRefs, validBackends...)
+					result.backendRefs = append(result.backendRefs, validBackends...)
 					envoyRoute.Action = &routev3.Route_Route{
 						Route: routeAction,
 					}
 				}
 			}
-			envoyRoutes = append(envoyRoutes, envoyRoute)
-		}
-
-		if len(rule.Matches) == 0 {
-			buildRoutesForRule(gatewayv1.HTTPRouteMatch{}, 0)
-		} else {
-			for matchIndex, match := range rule.Matches {
-				buildRoutesForRule(match, matchIndex)
-			}
+			result.routes = append(result.routes, envoyRoute)
 		}
 	}
 
-	if len(droppedRuleMessages) > 0 && len(envoyRoutes) == 0 {
+	if len(droppedRuleMessages) > 0 && len(result.routes) == 0 {
 		msg := fmt.Sprintf("no rules could be translated: %s", strings.Join(droppedRuleMessages, "; "))
 		cond := createNotAcceptedCondition(gatewayv1.RouteReasonUnsupportedValue, msg, httpRoute.Generation)
-		notAccepted = &cond
-		return nil, nil, notAccepted, nil, nil
+		return routeTranslationResult{notAccepted: &cond}
 	}
 
 	if len(droppedRuleMessages) > 0 {
 		msg := fmt.Sprintf("Dropped Rule(s): %s", strings.Join(droppedRuleMessages, "; "))
 		cond := createPartiallyInvalidCondition(msg, httpRoute.Generation)
-		partiallyInvalid = &cond
+		result.partiallyInvalid = &cond
 	}
-	return envoyRoutes, allValidBackendRefs, nil, resolvedRefsFailure, partiallyInvalid
+	return result
 }
 
 // findUnsupportedFilter returns the first filter type in the list that is not
@@ -199,7 +257,8 @@ func findUnsupportedFilter(filters []gatewayv1.HTTPRouteFilter) (gatewayv1.HTTPR
 	for _, filter := range filters {
 		switch filter.Type {
 		case gatewayv1.HTTPRouteFilterRequestRedirect,
-			gatewayv1.HTTPRouteFilterRequestHeaderModifier:
+			gatewayv1.HTTPRouteFilterRequestHeaderModifier,
+			gatewayv1.HTTPRouteFilterExternalAuth:
 		default:
 			return filter.Type, true
 		}

--- a/pkg/gateway/httproute_test.go
+++ b/pkg/gateway/httproute_test.go
@@ -351,7 +351,11 @@ func TestTranslateHTTPRouteToEnvoyRoutes(t *testing.T) {
 			route := baseRoute.DeepCopy()
 			route.Spec.Rules = tt.rules
 
-			routes, _, notAccepted, resolvedRefsFailure, partiallyInvalid := translateHTTPRouteToEnvoyRoutes(route, svcLister, noGrants)
+			got := translateHTTPRouteToEnvoyRoutes(route, svcLister, noGrants)
+			routes := got.routes
+			notAccepted := got.notAccepted
+			resolvedRefsFailure := got.resolvedRefsFailure
+			partiallyInvalid := got.partiallyInvalid
 
 			if len(routes) != tt.wantRoutes {
 				t.Errorf("got %d routes, want %d", len(routes), tt.wantRoutes)

--- a/pkg/gateway/listener.go
+++ b/pkg/gateway/listener.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/pem"
 	"fmt"
+	"slices"
 
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
@@ -209,7 +210,26 @@ func (c *Controller) validateListeners(gateway *gatewayv1.Gateway) map[gatewayv1
 	return listenerConditions
 }
 
-func (c *Controller) translateListenerToFilterChain(gateway *gatewayv1.Gateway, lis gatewayv1.Listener, virtualHosts []*routev3.VirtualHost, routeName string) (*listener.FilterChain, error) {
+// sortedHTTPFilters flattens the HTTP filters collected for a port into the
+// order they run in. Names are opaque, so the order is arbitrary but stable;
+// any feature that needs a specific ordering has to impose it here.
+func sortedHTTPFilters(filters map[string]*hcm.HttpFilter) []*hcm.HttpFilter {
+	names := make([]string, 0, len(filters))
+	for name := range filters {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+	ordered := make([]*hcm.HttpFilter, 0, len(names))
+	for _, name := range names {
+		ordered = append(ordered, filters[name])
+	}
+	return ordered
+}
+
+// translateListenerToFilterChain builds the Envoy filter chain for a listener.
+// extraHTTPFilters are inserted, in the given order, before the router filter of
+// the HTTP connection manager.
+func (c *Controller) translateListenerToFilterChain(gateway *gatewayv1.Gateway, lis gatewayv1.Listener, virtualHosts []*routev3.VirtualHost, routeName string, extraHTTPFilters []*hcm.HttpFilter) (*listener.FilterChain, error) {
 	var filterChain *listener.FilterChain
 
 	switch lis.Protocol {
@@ -220,6 +240,15 @@ func (c *Controller) translateListenerToFilterChain(gateway *gatewayv1.Gateway, 
 			klog.Errorf("Failed to marshal router config: %v", err)
 			return nil, err
 		}
+
+		httpFilters := make([]*hcm.HttpFilter, 0, len(extraHTTPFilters)+1)
+		httpFilters = append(httpFilters, extraHTTPFilters...)
+		httpFilters = append(httpFilters, &hcm.HttpFilter{
+			Name: wellknown.Router,
+			ConfigType: &hcm.HttpFilter_TypedConfig{
+				TypedConfig: routerAny,
+			},
+		})
 
 		hcmConfig := &hcm.HttpConnectionManager{
 			StatPrefix: string(lis.Name),
@@ -240,12 +269,7 @@ func (c *Controller) translateListenerToFilterChain(gateway *gatewayv1.Gateway, 
 					RouteConfigName: routeName,
 				},
 			},
-			HttpFilters: []*hcm.HttpFilter{{
-				Name: wellknown.Router,
-				ConfigType: &hcm.HttpFilter_TypedConfig{
-					TypedConfig: routerAny,
-				},
-			}},
+			HttpFilters: httpFilters,
 		}
 		hcmAny, err := anypb.New(hcmConfig)
 		if err != nil {

--- a/tests/gateway-experimental/manifests/multi_auth.yaml
+++ b/tests/gateway-experimental/manifests/multi_auth.yaml
@@ -114,11 +114,11 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: MyApp
+      app: MultiAuthApp
   template:
     metadata:
       labels:
-        app: MyApp
+        app: MultiAuthApp
     spec:
       containers:
       - name: myapp
@@ -133,7 +133,7 @@ metadata:
   name: myapp-svc
 spec:
   selector:
-    app: MyApp
+    app: MultiAuthApp
   ports:
   - port: 8080
     targetPort: 80

--- a/tests/gateway-experimental/manifests/multi_auth.yaml
+++ b/tests/gateway-experimental/manifests/multi_auth.yaml
@@ -1,0 +1,212 @@
+# A Gateway with three routes sharing one port: two protected by different
+# authorization servers and one left unprotected.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: authz-a-conf
+data:
+  default.conf: |
+    server {
+      listen 8080;
+      location / {
+        if ($http_authorization = "") {
+          return 401;
+        }
+        add_header X-Authenticated-User "alice";
+        return 200;
+      }
+    }
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: authz-b-conf
+data:
+  default.conf: |
+    server {
+      listen 8080;
+      location / {
+        if ($http_x_api_key = "") {
+          return 403;
+        }
+        return 200;
+      }
+    }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: authz-a
+spec:
+  selector:
+    matchLabels:
+      app: AuthzA
+  template:
+    metadata:
+      labels:
+        app: AuthzA
+    spec:
+      containers:
+      - name: authz
+        image: nginx:1.29-alpine
+        ports:
+        - containerPort: 8080
+        volumeMounts:
+        - name: conf
+          mountPath: /etc/nginx/conf.d
+      volumes:
+      - name: conf
+        configMap:
+          name: authz-a-conf
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: authz-b
+spec:
+  selector:
+    matchLabels:
+      app: AuthzB
+  template:
+    metadata:
+      labels:
+        app: AuthzB
+    spec:
+      containers:
+      - name: authz
+        image: nginx:1.29-alpine
+        ports:
+        - containerPort: 8080
+        volumeMounts:
+        - name: conf
+          mountPath: /etc/nginx/conf.d
+      volumes:
+      - name: conf
+        configMap:
+          name: authz-b-conf
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: authz-a-svc
+spec:
+  selector:
+    app: AuthzA
+  ports:
+  - port: 8080
+    targetPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: authz-b-svc
+spec:
+  selector:
+    app: AuthzB
+  ports:
+  - port: 8080
+    targetPort: 8080
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myapp
+spec:
+  selector:
+    matchLabels:
+      app: MyApp
+  template:
+    metadata:
+      labels:
+        app: MyApp
+    spec:
+      containers:
+      - name: myapp
+        image: registry.k8s.io/e2e-test-images/agnhost:2.66.1
+        args: ["netexec", "--http-port=80"]
+        ports:
+        - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: myapp-svc
+spec:
+  selector:
+    app: MyApp
+  ports:
+  - port: 8080
+    targetPort: 80
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: multi-auth-gw
+spec:
+  gatewayClassName: cloud-provider-kind
+  listeners:
+  - name: http
+    port: 80
+    protocol: HTTP
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: route-a
+spec:
+  parentRefs:
+  - name: multi-auth-gw
+  hostnames:
+  - a.auth.test
+  rules:
+  - filters:
+    - type: ExternalAuth
+      externalAuth:
+        protocol: HTTP
+        backendRef:
+          name: authz-a-svc
+          port: 8080
+        http:
+          allowedResponseHeaders:
+          - X-Authenticated-User
+    backendRefs:
+    - name: myapp-svc
+      port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: route-b
+spec:
+  parentRefs:
+  - name: multi-auth-gw
+  hostnames:
+  - b.auth.test
+  rules:
+  - filters:
+    - type: ExternalAuth
+      externalAuth:
+        protocol: HTTP
+        backendRef:
+          name: authz-b-svc
+          port: 8080
+        http:
+          allowedHeaders:
+          - X-Api-Key
+    backendRefs:
+    - name: myapp-svc
+      port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: route-open
+spec:
+  parentRefs:
+  - name: multi-auth-gw
+  hostnames:
+  - open.auth.test
+  rules:
+  - backendRefs:
+    - name: myapp-svc
+      port: 8080

--- a/tests/gateway-experimental/manifests/unresolvable_auth_backend.yaml
+++ b/tests/gateway-experimental/manifests/unresolvable_auth_backend.yaml
@@ -1,0 +1,33 @@
+# An ExternalAuth filter pointing at a Service that does not exist. The rule
+# must fail closed instead of forwarding unauthorized traffic.
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: test-gw-extauth
+spec:
+  gatewayClassName: cloud-provider-kind
+  listeners:
+  - name: http
+    port: 80
+    protocol: HTTP
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: test-route-extauth
+spec:
+  parentRefs:
+  - name: test-gw-extauth
+  rules:
+  - filters:
+    - type: ExternalAuth
+      externalAuth:
+        protocol: HTTP
+        backendRef:
+          name: does-not-exist
+          port: 8080
+        http:
+          path: /auth
+    backendRefs:
+    - name: does-not-exist
+      port: 8080

--- a/tests/gateway-experimental/setup_suite.bash
+++ b/tests/gateway-experimental/setup_suite.bash
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -eu
+
+function setup_suite {
+  export BATS_TEST_TIMEOUT=300
+  # Define the name of the kind cluster
+  export CLUSTER_NAME="ccm-kind-gateway-experimental"
+
+  export ARTIFACTS_DIR="$BATS_TEST_DIRNAME"/../../_artifacts-gateway-experimental
+  mkdir -p "$ARTIFACTS_DIR"
+  rm -rf "$ARTIFACTS_DIR"/*
+
+  # Clean up any leftover cluster from a previous run
+  kind delete cluster --name "$CLUSTER_NAME" 2>/dev/null || true
+
+  # create cluster
+  kind create cluster --name $CLUSTER_NAME -v7 --wait 1m --retain --config="$BATS_TEST_DIRNAME/../kind.yaml"
+
+  # The experimental channel is required by the Gateway API features still under
+  # development, such as the ExternalAuth HTTPRoute filter (GEP-1494).
+  cd "$BATS_TEST_DIRNAME"/../.. && make
+  nohup "$BATS_TEST_DIRNAME"/../../bin/cloud-provider-kind -v 2 --gateway-channel=experimental --enable-lb-port-mapping --enable-log-dumping --logs-dir "$ARTIFACTS_DIR" > "$ARTIFACTS_DIR"/ccm-kind.log 2>&1 &
+  export CCM_PID=$!
+
+  # test depend on external connectivity that can be very flaky
+  sleep 5
+}
+
+function teardown_suite {
+    kill "${CCM_PID:-}" 2>/dev/null || true
+    kind export logs "$ARTIFACTS_DIR" --name "$CLUSTER_NAME"
+    kind delete cluster --name "$CLUSTER_NAME"
+}

--- a/tests/gateway-experimental/tests.bats
+++ b/tests/gateway-experimental/tests.bats
@@ -27,17 +27,37 @@ http_status() {
     echo "000"
 }
 
+# wait_no_pods returns once no pods match the selector. kubectl delete of a
+# Deployment is background-cascaded, so leftover pods from a previous test can
+# still be terminating when the next test waits on the same labels.
+wait_no_pods() {
+    local selector="$1" i
+    for ((i = 0; i < 60; i++)); do
+        [[ -z $(kubectl get pods -l "$selector" -o name --no-headers 2>/dev/null) ]] && return 0
+        sleep 1
+    done
+    echo "Timeout waiting for pods with $selector to be gone" >&2
+    kubectl get pods -l "$selector" >&2 || true
+    return 1
+}
+
 # apply_multi_auth brings up two authorization servers, a backend and the routes
 # that use them, then waits for every pod to be ready.
 apply_multi_auth() {
+    wait_no_pods app=MultiAuthApp
+    wait_no_pods app=AuthzA
+    wait_no_pods app=AuthzB
     kubectl apply -f "$BATS_TEST_DIRNAME"/manifests/multi_auth.yaml
-    kubectl wait --for=condition=ready pods -l app=MyApp --timeout=120s
+    kubectl wait --for=condition=ready pods -l app=MultiAuthApp --timeout=120s
     kubectl wait --for=condition=ready pods -l app=AuthzA --timeout=120s
     kubectl wait --for=condition=ready pods -l app=AuthzB --timeout=120s
 }
 
 delete_multi_auth() {
     kubectl delete --ignore-not-found -f "$BATS_TEST_DIRNAME"/manifests/multi_auth.yaml
+    wait_no_pods app=MultiAuthApp
+    wait_no_pods app=AuthzA
+    wait_no_pods app=AuthzB
 }
 
 # wait_for_feature waits until the GatewayClass advertises a feature. The name is
@@ -79,6 +99,8 @@ wait_for_feature() {
     [ "$HOSTNAME" = "$POD" ]
 
     kubectl delete --ignore-not-found -f "$BATS_TEST_DIRNAME"/../../examples/gateway_external_auth.yaml
+    wait_no_pods app=MyApp
+    wait_no_pods app=Authz
 }
 
 @test "ExternalAuth filter with an unresolvable backendRef fails closed" {

--- a/tests/gateway-experimental/tests.bats
+++ b/tests/gateway-experimental/tests.bats
@@ -1,0 +1,169 @@
+#!/usr/bin/env bats
+
+# GEP-1494 (HTTP Auth) end to end tests. They need the experimental Gateway API
+# channel because the ExternalAuth filter is not part of the standard CRDs.
+
+gateway_ip() {
+    local name="$1" ip i
+    for ((i = 0; i < 30; i++)); do
+        ip=$(kubectl get gateway "$name" -o jsonpath='{.status.addresses[0].value}' 2>/dev/null)
+        [[ -n "$ip" ]] && echo "$ip" && return 0
+        sleep 1
+    done
+    echo "Timeout waiting for an address on gateway/$name" >&2
+    return 1
+}
+
+# http_status retries until the gateway answers, then echoes the status code.
+http_status() {
+    local url="$1"
+    shift
+    local code i
+    for ((i = 0; i < 30; i++)); do
+        code=$(curl -s -o /dev/null -w '%{http_code}' --connect-timeout 5 "$@" "$url" || true)
+        [[ "$code" != "000" ]] && echo "$code" && return 0
+        sleep 1
+    done
+    echo "000"
+}
+
+# apply_multi_auth brings up two authorization servers, a backend and the routes
+# that use them, then waits for every pod to be ready.
+apply_multi_auth() {
+    kubectl apply -f "$BATS_TEST_DIRNAME"/manifests/multi_auth.yaml
+    kubectl wait --for=condition=ready pods -l app=MyApp --timeout=120s
+    kubectl wait --for=condition=ready pods -l app=AuthzA --timeout=120s
+    kubectl wait --for=condition=ready pods -l app=AuthzB --timeout=120s
+}
+
+delete_multi_auth() {
+    kubectl delete --ignore-not-found -f "$BATS_TEST_DIRNAME"/manifests/multi_auth.yaml
+}
+
+# wait_for_feature waits until the GatewayClass advertises a feature. The name is
+# matched exactly, because the GEP-1494 names are prefixes of each other.
+wait_for_feature() {
+    local name="$1" got i
+    for ((i = 0; i < 30; i++)); do
+        got=$(kubectl get gatewayclass cloud-provider-kind \
+            -o "jsonpath={.status.supportedFeatures[?(@.name==\"$name\")].name}" 2>/dev/null)
+        [[ "$got" == "$name" ]] && return 0
+        sleep 1
+    done
+    echo "Timeout: GatewayClass does not advertise feature $name" >&2
+    return 1
+}
+
+# ---------------------------------------------------------------------------
+
+@test "ExternalAuth filter denies unauthenticated requests and allows authenticated ones" {
+    kubectl apply -f "$BATS_TEST_DIRNAME"/../../examples/gateway_external_auth.yaml
+
+    kubectl wait --for=condition=ready pods -l app=MyApp --timeout=120s
+    kubectl wait --for=condition=ready pods -l app=Authz --timeout=120s
+
+    IP=$(gateway_ip prod-web)
+    echo "Gateway IP: $IP"
+
+    # No Authorization header: the authorization server rejects the request and
+    # it must never reach the backend.
+    run http_status "http://${IP}/hostname"
+    [ "$output" = "401" ]
+
+    # With an Authorization header the request is authorized and forwarded.
+    run http_status "http://${IP}/hostname" -H 'Authorization: Bearer token'
+    [ "$output" = "200" ]
+
+    POD=$(kubectl get pod -l app=MyApp -o jsonpath='{.items[0].metadata.name}')
+    HOSTNAME=$(curl -s --connect-timeout 5 -H 'Authorization: Bearer token' "http://${IP}/hostname")
+    [ "$HOSTNAME" = "$POD" ]
+
+    kubectl delete --ignore-not-found -f "$BATS_TEST_DIRNAME"/../../examples/gateway_external_auth.yaml
+}
+
+@test "ExternalAuth filter with an unresolvable backendRef fails closed" {
+    kubectl apply -f "$BATS_TEST_DIRNAME"/manifests/unresolvable_auth_backend.yaml
+
+    for i in {1..60}; do
+        REASON=$(kubectl get httproute test-route-extauth \
+            -o 'jsonpath={.status.parents[0].conditions[?(@.type=="ResolvedRefs")].reason}' 2>/dev/null)
+        [[ "$REASON" == "BackendNotFound" ]] && break
+        sleep 1
+    done
+
+    run kubectl get httproute test-route-extauth \
+        -o 'jsonpath={.status.parents[0].conditions[?(@.type=="ResolvedRefs")].status}'
+    [ "$output" = "False" ]
+
+    run kubectl get httproute test-route-extauth \
+        -o 'jsonpath={.status.parents[0].conditions[?(@.type=="ResolvedRefs")].reason}'
+    [ "$output" = "BackendNotFound" ]
+
+    IP=$(gateway_ip test-gw-extauth)
+    run http_status "http://${IP}/"
+    [ "$output" = "500" ]
+
+    kubectl delete --ignore-not-found -f "$BATS_TEST_DIRNAME"/manifests/unresolvable_auth_backend.yaml
+}
+
+@test "GatewayClass advertises the GEP-1494 features on the experimental channel" {
+    wait_for_feature HTTPRouteExternalAuth
+    wait_for_feature HTTPRouteExternalAuthHTTP
+    wait_for_feature HTTPRouteExternalAuthGRPC
+    wait_for_feature HTTPRouteExternalAuthForwardBody
+}
+
+@test "each route uses its own authorization server and unprotected routes are untouched" {
+    apply_multi_auth
+    IP=$(gateway_ip multi-auth-gw)
+    echo "Gateway IP: $IP"
+
+    # route-a only accepts an Authorization header.
+    run http_status "http://${IP}/hostname" -H 'Host: a.auth.test'
+    [ "$output" = "401" ]
+    run http_status "http://${IP}/hostname" -H 'Host: a.auth.test' -H 'Authorization: Bearer token'
+    [ "$output" = "200" ]
+    # The credential accepted by route-a must not unlock route-b.
+    run http_status "http://${IP}/hostname" -H 'Host: b.auth.test' -H 'Authorization: Bearer token'
+    [ "$output" = "403" ]
+
+    # route-b only accepts an API key, and returns its own denial status.
+    run http_status "http://${IP}/hostname" -H 'Host: b.auth.test'
+    [ "$output" = "403" ]
+    run http_status "http://${IP}/hostname" -H 'Host: b.auth.test' -H 'X-Api-Key: secret'
+    [ "$output" = "200" ]
+
+    # route-open has no ExternalAuth filter, so the ext_authz filters installed
+    # on the shared connection manager must stay disabled for it.
+    run http_status "http://${IP}/hostname" -H 'Host: open.auth.test'
+    [ "$output" = "200" ]
+
+    delete_multi_auth
+}
+
+@test "headers from the authorization response are forwarded to the backend" {
+    apply_multi_auth
+    IP=$(gateway_ip multi-auth-gw)
+
+    run http_status "http://${IP}/hostname" -H 'Host: a.auth.test' -H 'Authorization: Bearer token'
+    [ "$output" = "200" ]
+
+    # agnhost echoes back the value of the requested header, which proves the
+    # authorization server response header reached the backend.
+    for i in {1..15}; do
+        USER=$(curl -s --connect-timeout 5 -H 'Host: a.auth.test' -H 'Authorization: Bearer token' \
+            "http://${IP}/header?key=X-Authenticated-User" || true)
+        [[ -n "$USER" ]] && break
+        sleep 1
+    done
+    [ "$USER" = "alice" ]
+
+    # route-b does not allow any response header through.
+    run http_status "http://${IP}/hostname" -H 'Host: b.auth.test' -H 'X-Api-Key: secret'
+    [ "$output" = "200" ]
+    USER_B=$(curl -s --connect-timeout 5 -H 'Host: b.auth.test' -H 'X-Api-Key: secret' \
+        "http://${IP}/header?key=X-Authenticated-User" || true)
+    [ -z "$USER_B" ]
+
+    delete_multi_auth
+}


### PR DESCRIPTION
Add support for the experimental ExternalAuth HTTPRoute filter, which delegates authentication and authorization for a route rule to an external server speaking Envoy's ext_authz protocol over HTTP or GRPC.

The GEP-1494 feature names are only advertised on the GatewayClass when running the experimental release channel, where the CRD fields exist.

/assign @youngnick @snorwin @bittrance 

