### PR TITLE
Programmed status now depends on Envoy response

### DIFF
--- a/pkg/container/container.go
+++ b/pkg/container/container.go
@@ -114,6 +114,14 @@ func Delete(name string) error {
 	return nil
 }
 
+func State(name string) string {
+	out, err := exec.Command(containerRuntime, "inspect", "--format", "{{.State.Status}}", name).Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
 func IsRunning(name string) bool {
 	cmd := exec.Command(containerRuntime, []string{"ps", "-q", "-f", "name=" + name}...)
 	output, err := cmd.Output()

--- a/pkg/gateway/controller.go
+++ b/pkg/gateway/controller.go
@@ -18,14 +18,18 @@ package gateway
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"net"
 	"sort"
-	"sync/atomic"
+	"strings"
+	"sync"
 	"time"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/keepalive"
+	"google.golang.org/protobuf/proto"
 
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	clusterv3service "github.com/envoyproxy/go-control-plane/envoy/service/cluster/v3"
@@ -121,7 +125,14 @@ type Controller struct {
 	xdsserver       serverv3.Server
 	xdsLocalAddress string
 	xdsLocalPort    int
-	xdsVersion      atomic.Uint64
+
+	// xdsGatewayState maps the xDS node ID (gatewaySimpleName, i.e.
+	// "clusterName/namespace/name") to the gateway's current sync state.
+	// The value is one of:
+	//   string → content hash of a push that Envoy has not yet ACK'd or NACK'd
+	//   error  → the error from Envoy's most recent NACK
+	//   absent → the last push was confirmed by an Envoy ACK (or nothing pushed)
+	xdsGatewayState sync.Map
 
 	tunnelManager *tunnels.TunnelManager
 }
@@ -403,7 +414,7 @@ func (c *Controller) Run(ctx context.Context) error {
 
 	logger.Info("Starting Envoy proxy controller")
 	c.xdscache = cachev3.NewSnapshotCache(false, cachev3.IDHash{}, nil)
-	c.xdsserver = serverv3.NewServer(ctx, c.xdscache, &xdsCallbacks{})
+	c.xdsserver = serverv3.NewServer(ctx, c.xdscache, &xdsCallbacks{ctrl: c})
 
 	var grpcOptions []grpc.ServerOption
 	grpcOptions = append(grpcOptions,
@@ -721,14 +732,10 @@ func GetControlPlaneAddress() (string, error) {
 }
 
 func (c *Controller) UpdateXDSServer(ctx context.Context, nodeid string, resources map[resourcev3.Type][]envoyproxytypes.Resource) error {
-	c.xdsVersion.Add(1)
-
-	snapshot, err := cachev3.NewSnapshot(fmt.Sprintf("%d", c.xdsVersion.Load()), resources)
+	snapshot, err := cachev3.NewSnapshot(computeResourcesHash(resources), resources)
 	if err != nil {
 		return fmt.Errorf("failed to create new snapshot cache: %v", err)
-
 	}
-
 	if err := c.xdscache.SetSnapshot(ctx, nodeid, snapshot); err != nil {
 		return fmt.Errorf("failed to update resource snapshot in management server: %v", err)
 	}
@@ -739,7 +746,9 @@ func (c *Controller) UpdateXDSServer(ctx context.Context, nodeid string, resourc
 
 var _ serverv3.Callbacks = &xdsCallbacks{}
 
-type xdsCallbacks struct{}
+type xdsCallbacks struct {
+	ctrl *Controller
+}
 
 func (cb *xdsCallbacks) OnStreamOpen(ctx context.Context, id int64, typ string) error {
 	klog.V(2).Infof("xDS stream %d opened for type %s", id, typ)
@@ -753,7 +762,31 @@ func (cb *xdsCallbacks) OnStreamClosed(id int64, node *corev3.Node) {
 	klog.V(2).Infof("xDS stream %d closed for node %s", id, nodeID)
 }
 func (cb *xdsCallbacks) OnStreamRequest(id int64, req *discoveryv3.DiscoveryRequest) error {
-	klog.V(5).Infof("xDS stream %d received request for type %s from node %s", id, req.TypeUrl, req.Node.GetId())
+	nodeID := req.Node.GetId()
+	klog.V(5).Infof("xDS stream %d received request for type %s from node %s", id, req.TypeUrl, nodeID)
+
+	requeue := func() {
+		prefix := cb.ctrl.clusterName + "/"
+		if strings.HasPrefix(nodeID, prefix) {
+			cb.ctrl.gatewayqueue.Add(strings.TrimPrefix(nodeID, prefix))
+		}
+	}
+
+	if req.ErrorDetail != nil {
+		nackerr := fmt.Errorf("%s", req.ErrorDetail.Message)
+		prev, _ := cb.ctrl.xdsGatewayState.Swap(nodeID, nackerr)
+		if _, wasAlreadyNACKed := prev.(error); !wasAlreadyNACKed {
+			klog.Warningf("xDS NACK from node %s (type %s): %s", nodeID, req.TypeUrl, req.ErrorDetail.Message)
+			requeue()
+		}
+	} else if v, ok := cb.ctrl.xdsGatewayState.Load(nodeID); ok {
+		if pendingHash, isStr := v.(string); isStr && pendingHash == req.VersionInfo {
+			cb.ctrl.xdsGatewayState.Delete(nodeID)
+			klog.V(4).Infof("xDS ACK from node %s (type %s): config confirmed", nodeID, req.TypeUrl)
+			requeue()
+		}
+	}
+
 	return nil
 }
 func (cb *xdsCallbacks) OnStreamResponse(ctx context.Context, id int64, req *discoveryv3.DiscoveryRequest, resp *discoveryv3.DiscoveryResponse) {
@@ -774,4 +807,31 @@ func (cb *xdsCallbacks) OnStreamDeltaResponse(id int64, req *discoveryv3.DeltaDi
 func (cb *xdsCallbacks) OnDeltaStreamClosed(int64, *corev3.Node) {}
 func (cb *xdsCallbacks) OnDeltaStreamOpen(context.Context, int64, string) error {
 	return nil
+}
+
+// computeResourcesHash returns a SHA-256 content hash of the given xDS
+// resources, used as the snapshot version string. Within each type the
+// serialised resource bytes are sorted before hashing so the result is stable
+func computeResourcesHash(resources map[resourcev3.Type][]envoyproxytypes.Resource) string {
+	h := sha256.New()
+	typeKeys := make([]string, 0, len(resources))
+	for t := range resources {
+		typeKeys = append(typeKeys, string(t))
+	}
+	sort.Strings(typeKeys)
+	for _, t := range typeKeys {
+		rs := resources[resourcev3.Type(t)]
+		serialised := make([][]byte, len(rs))
+		for i, r := range rs {
+			serialised[i], _ = proto.MarshalOptions{Deterministic: true}.Marshal(r)
+		}
+		sort.Slice(serialised, func(i, j int) bool {
+			return string(serialised[i]) < string(serialised[j])
+		})
+		h.Write([]byte(t))
+		for _, b := range serialised {
+			h.Write(b)
+		}
+	}
+	return hex.EncodeToString(h.Sum(nil))
 }

--- a/pkg/gateway/envoy.go
+++ b/pkg/gateway/envoy.go
@@ -133,7 +133,7 @@ func createGateway(clusterName string, nameserver string, localAddress string, l
 	name := gatewayName(clusterName, gateway.Namespace, gateway.Name)
 	simpleName := gatewaySimpleName(clusterName, gateway.Namespace, gateway.Name)
 	envoyConfigData := &configData{
-		ID:                  name,
+		ID:                  simpleName,
 		Cluster:             simpleName,
 		AdminPort:           envoyAdminPort,
 		ControlPlaneAddress: localAddress,

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -91,8 +91,13 @@ func (c *Controller) syncGateway(ctx context.Context, key string) error {
 	setAcceptedCondition(newGw)
 
 	var xdsErr error
+	var pendingACK bool
 	if meta.IsStatusConditionTrue(newGw.Status.Conditions, string(gatewayv1.GatewayConditionAccepted)) {
 		containerName := gatewayName(c.clusterName, namespace, name)
+		// xdsNodeID is the xDS node ID Envoy reports in its bootstrap config.
+		// It encodes the queue key so the callback can re-queue without a
+		// separate lookup map.
+		xdsNodeID := gatewaySimpleName(c.clusterName, namespace, name)
 		klog.Infof("Syncing Gateway %s, container %s", key, containerName)
 
 		err = c.ensureGatewayContainer(ctx, gw)
@@ -124,8 +129,40 @@ func (c *Controller) syncGateway(ctx context.Context, key string) error {
 				})
 		}
 
-		// Apply the desired state to the data plane (Envoy).
-		xdsErr = c.UpdateXDSServer(ctx, containerName, envoyResources)
+		currentHash := computeResourcesHash(envoyResources)
+		snapHash := ""
+		if snap, err := c.xdscache.GetSnapshot(xdsNodeID); err == nil {
+			snapHash = snap.GetVersion(resourcev3.ListenerType)
+		}
+
+		v, _ := c.xdsGatewayState.Load(xdsNodeID)
+		var needsPush bool
+		switch state := v.(type) {
+		case error:
+			if snapHash == currentHash {
+				xdsErr = state // same config was NACKed — surface the error
+			} else {
+				c.xdsGatewayState.Delete(xdsNodeID) // config changed — clear stale NACK
+				needsPush = true
+			}
+		case string:
+			if state == currentHash {
+				pendingACK = true // same config, still awaiting Envoy's reply
+			} else {
+				needsPush = true // config changed while waiting — push the new version
+			}
+		default:
+			if snapHash != currentHash {
+				needsPush = true // new or changed config — push it
+			}
+			// else: same config, previously ACKed → Programmed=True (no action)
+		}
+		if needsPush {
+			if xdsErr = c.UpdateXDSServer(ctx, xdsNodeID, envoyResources); xdsErr == nil {
+				c.xdsGatewayState.Store(xdsNodeID, currentHash)
+				pendingACK = true
+			}
+		}
 
 		// forward traffic from the host on Mac and Windows
 		if c.tunnelManager != nil {
@@ -136,12 +173,27 @@ func (c *Controller) syncGateway(ctx context.Context, key string) error {
 		}
 	}
 
-	setProgrammedCondition(newGw, xdsErr)
+	setProgrammedCondition(newGw, xdsErr, pendingACK)
 
 	if !reflect.DeepEqual(gw.Status, newGw.Status) {
-		_, err := c.gwClient.GatewayV1().Gateways(newGw.Namespace).UpdateStatus(ctx, newGw, metav1.UpdateOptions{})
+		desiredStatus := newGw.Status
+		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			latestGw, err := c.gatewayLister.Gateways(newGw.Namespace).Get(newGw.Name)
+			if apierrors.IsNotFound(err) {
+				return nil
+			} else if err != nil {
+				return err
+			}
+			gwToUpdate := latestGw.DeepCopy()
+			gwToUpdate.Status = desiredStatus
+			if semanticIgnoreLastTransitionTime.DeepEqual(latestGw.Status, gwToUpdate.Status) {
+				return nil
+			}
+			_, updateErr := c.gwClient.GatewayV1().Gateways(gwToUpdate.Namespace).UpdateStatus(ctx, gwToUpdate, metav1.UpdateOptions{})
+			return updateErr
+		})
 		if err != nil {
-			klog.Errorf("Failed to update gateway status: %v", err)
+			klog.Errorf("failed to update gateway status: %v", err)
 			return err
 		}
 	}
@@ -726,20 +778,22 @@ func (c *Controller) translateBackendRefToCluster(defaultNamespace string, backe
 func (c *Controller) deleteGatewayResources(ctx context.Context, name, namespace string) error {
 	klog.Infof("Deleting resources for Gateway: %s/%s", namespace, name)
 	containerName := gatewayName(c.clusterName, namespace, name)
+	xdsNodeID := gatewaySimpleName(c.clusterName, namespace, name)
 
-	c.xdsVersion.Add(1)
-	version := fmt.Sprintf("%d", c.xdsVersion.Load())
+	// Clean up xDS sync state for this gateway.
+	c.xdsGatewayState.Delete(xdsNodeID)
 
-	snapshot, err := cachev3.NewSnapshot(version, map[resourcev3.Type][]envoyproxytypes.Resource{
+	emptyResources := map[resourcev3.Type][]envoyproxytypes.Resource{
 		resourcev3.ListenerType: {},
 		resourcev3.RouteType:    {},
 		resourcev3.ClusterType:  {},
 		resourcev3.EndpointType: {},
-	})
+	}
+	snapshot, err := cachev3.NewSnapshot(computeResourcesHash(emptyResources), emptyResources)
 	if err != nil {
 		return fmt.Errorf("failed to create empty snapshot for deleted gateway %s: %w", name, err)
 	}
-	if err := c.xdscache.SetSnapshot(ctx, containerName, snapshot); err != nil {
+	if err := c.xdscache.SetSnapshot(ctx, xdsNodeID, snapshot); err != nil {
 		return fmt.Errorf("failed to set empty snapshot for deleted gateway %s: %w", name, err)
 	}
 
@@ -846,9 +900,10 @@ func setAcceptedCondition(newGw *gatewayv1.Gateway) {
 	}
 }
 
-// setProgrammedCondition sets the Programmed condition for the Gateway.
+// pendingACK is true when a config push has been sent to Envoy but Envoy has
+// not yet replied with an ACK or NACK; in that case the condition is Unknown.
 // Accepted is expected to already be set on newGw by the time this is called.
-func setProgrammedCondition(newGw *gatewayv1.Gateway, xdsErr error) {
+func setProgrammedCondition(newGw *gatewayv1.Gateway, xdsErr error, pendingACK bool) {
 	switch {
 	case meta.IsStatusConditionFalse(newGw.Status.Conditions, string(gatewayv1.GatewayConditionAccepted)):
 		// A Gateway can never be Programmed=True if Accepted=False.
@@ -866,6 +921,14 @@ func setProgrammedCondition(newGw *gatewayv1.Gateway, xdsErr error) {
 			Status:             metav1.ConditionFalse,
 			Reason:             "ReconciliationError",
 			Message:            fmt.Sprintf("Failed to program envoy config: %s", xdsErr.Error()),
+			ObservedGeneration: newGw.Generation,
+		})
+	case pendingACK:
+		meta.SetStatusCondition(&newGw.Status.Conditions, metav1.Condition{
+			Type:               string(gatewayv1.GatewayConditionProgrammed),
+			Status:             metav1.ConditionUnknown,
+			Reason:             "Pending",
+			Message:            "Waiting for Envoy to confirm the configuration",
 			ObservedGeneration: newGw.Generation,
 		})
 	default:

--- a/pkg/gateway/kindcluster.go
+++ b/pkg/gateway/kindcluster.go
@@ -147,8 +147,10 @@ func (c *Controller) configureContainerNetworking(ctx context.Context, container
 	stdinReader := bytes.NewReader(binaryData)
 
 	klog.Infof("Streaming and setting up route-adder utility in %s", containerName)
-	if err := container.Exec(containerName, setupCmd, stdinReader, nil, nil); err != nil {
-		return fmt.Errorf("failed to setup route-adder binary in container %s: %w", containerName, err)
+	var setupStdout, setupStderr bytes.Buffer
+	if err := container.Exec(containerName, setupCmd, stdinReader, &setupStdout, &setupStderr); err != nil {
+		return fmt.Errorf("failed to setup route-adder binary in container %s: %w, stdout: %s, stderr: %s",
+			containerName, err, setupStdout.String(), setupStderr.String())
 	}
 	klog.Infof("Successfully installed route-adder utility in container %s", containerName)
 	routeMap, err := c.getClusterRoutingMap(ctx)
@@ -185,15 +187,9 @@ func (c *Controller) ensureGatewayContainer(ctx context.Context, gw *gatewayv1.G
 	name := gw.Name
 	containerName := gatewayName(c.clusterName, namespace, name)
 
-	if !container.IsRunning(containerName) {
-		klog.Infof("container %s for gateway %s/%s is not running", containerName, namespace, name)
-		if container.Exist(containerName) {
-			if err := container.Delete(containerName); err != nil {
-				return err
-			}
-		}
-	}
-	if !container.Exist(containerName) {
+	state := container.State(containerName)
+	switch state {
+	case "":
 		klog.V(2).Infof("creating container %s for gateway  %s/%s on cluster %s", containerName, namespace, name, c.clusterName)
 		enableTunnels := c.tunnelManager != nil || config.DefaultConfig.LoadBalancerConnectivity == config.Portmap
 		err := createGateway(c.clusterName, c.clusterNameserver, c.xdsLocalAddress, c.xdsLocalPort, gw, enableTunnels)
@@ -210,6 +206,15 @@ func (c *Controller) ensureGatewayContainer(ctx context.Context, gw *gatewayv1.G
 			}
 			return fmt.Errorf("failed to configure networking for new gateway container %s: %w", containerName, err)
 		}
+	case "running":
+		klog.V(2).Infof("container %s for gateway %s/%s on cluster %s exists", containerName, namespace, name, c.clusterName)
+	case "exited", "dead":
+		// Truly stopped — safe to remove and recreate.
+		if err := container.Delete(containerName); err != nil {
+			return err
+		}
+	default:
+		return fmt.Errorf("container %s is in unexpected state %q, will retry", containerName, state)
 	}
 	return nil
 }

--- a/tests/gateway_api.bats
+++ b/tests/gateway_api.bats
@@ -191,6 +191,62 @@ EOF
     kubectl delete gateway test-gw-accepted --ignore-not-found
 }
 
+
+# When an HTTPRoute carries an invalid RE2 regex path match, Envoy rejects the
+# xDS update asynchronously via a NACK. The controller observes the NACK through
+# the OnStreamRequest callback, stores the error, and surfaces it on the next
+# reconciliation so that Programmed is correctly set to False.
+@test "Gateway is set to Programmed=False when an HTTPRoute uses an invalid regex (Envoy NACK observed)" {
+    kubectl delete gateway test-gw-bad-regex --ignore-not-found
+    kubectl delete httproute test-route-bad-regex --ignore-not-found
+
+    kubectl apply -f - <<'EOF'
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: test-gw-bad-regex
+spec:
+  gatewayClassName: cloud-provider-kind
+  listeners:
+  - name: http
+    port: 80
+    protocol: HTTP
+    allowedRoutes:
+      namespaces:
+        from: Same
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: test-route-bad-regex
+spec:
+  parentRefs:
+  - name: test-gw-bad-regex
+  rules:
+  - matches:
+    - path:
+        type: RegularExpression
+        value: "[invalid"
+    backendRefs:
+    - name: some-svc
+      port: 80
+EOF
+
+    wait_for_gateway_condition test-gw-bad-regex Programmed False 60
+
+    run kubectl get gateway test-gw-bad-regex \
+        -o 'jsonpath={.status.conditions[?(@.type=="Accepted")].status}'
+    [ "$output" = "True" ]
+
+    run kubectl get gateway test-gw-bad-regex \
+        -o 'jsonpath={.status.conditions[?(@.type=="Programmed")].status}'
+    echo "$output"
+    [ "$output" = "False" ]
+
+    kubectl delete httproute test-route-bad-regex --ignore-not-found
+    kubectl delete gateway test-gw-bad-regex --ignore-not-found
+}
+
 @test "Gateway routes HTTP traffic to pod" {
     # Apply the Gateway and HTTPRoute manifests
     kubectl apply -f "$BATS_TEST_DIRNAME"/../examples/gateway_httproute_simple.yaml


### PR DESCRIPTION
cloud-provider-kind currently ignores Envoy's response to xds message. This leads to two different problems:

- we set Programmed=True before Envoy is actually programmed
- when Envoy rejects the configuration as invalid (e.g. bad regex) we still claim it is programmed

This PR has the controller track outstanding Envoy config requests and triggers another reconciliation when Envoy replies, this keeping the previous status until we know the new Programmed status.

I'm putting this PR up for visibility. However, it currently has a subtle race condition where an invalid configuration can put the Gateway controller in a (possibly infinite) reconcile loop. More digging is needed.

Fixes #452 .