### PR TITLE
feat: add BackendTLSPolicy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,11 @@ NET_MODE=kind docker compose up -d
 ## Gateway API support
 
 This provider has support for the [Gateway API](https://gateway-api.sigs.k8s.io/).
-It implements the `Gateway` and `HTTPRoute` functionalities and passes the community conformance tests.
+It implements the `Gateway` and `HTTPRoute` functionalities and advertises those
+features on `GatewayClass`. The Gateway HTTP conformance suite runs against this class.
+
+`BackendTLSPolicy` is an Extended feature. See
+[Gateway API support](docs/user/gateway/gatewayapi.md).
 
 The Gateway API controller is enabled by default using the standard channel,
 but you can select the Gateway API release channel (standard/experimental) or just disable the feature completely
@@ -325,6 +329,11 @@ and test that works:
 $ curl 192.168.8.5/hostname
 myapp-7dcffbf547-9kl2d
 ```
+
+To make the Gateway connect to the Service over TLS, apply a `BackendTLSPolicy`
+and a ConfigMap with the CA in `ca.crt`. See
+[`examples/gateway_backendtlspolicy.yaml`](examples/gateway_backendtlspolicy.yaml)
+and [Securing backend TLS with BackendTLSPolicy](docs/user/example/creating_gateway_backendtlspolicy.md).
 
 ### Enabling Load Balancer Port Mapping
 

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -13,6 +13,7 @@
 - Usage Examples
   - [Creating service via a LoadBalancer](user/example/service_expose_via_loadbalancer.md)
   - [Creating a Gateway and a HTTPRoute](user/example/creating_gateway_http_route.md.md)
+  - [Securing backend TLS with BackendTLSPolicy](user/example/creating_gateway_backendtlspolicy.md)
   - [Enabling Load Balancer Port Mapping](user/example/enable_lb_port_mapping.md)
 
 - Support

--- a/docs/user/example/creating_gateway_backendtlspolicy.md
+++ b/docs/user/example/creating_gateway_backendtlspolicy.md
@@ -1,0 +1,69 @@
+### Securing backend TLS with BackendTLSPolicy
+
+`BackendTLSPolicy` tells the Gateway to connect to a Service over TLS and to
+check the backend certificate. Put the CA PEM in a ConfigMap key named `ca.crt`.
+Set `validation.hostname` to the name on that certificate.
+
+The backend must serve TLS. The Gateway does not send plaintext to the Service
+when a policy applies.
+
+Create a ConfigMap from a CA file, then apply the policy with the Gateway and
+HTTPRoute. A complete example is in `examples/gateway_backendtlspolicy.yaml`.
+
+```sh
+kubectl create configmap backend-ca --from-file=ca.crt=ca.crt
+```
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: prod-web
+spec:
+  gatewayClassName: cloud-provider-kind
+  listeners:
+  - protocol: HTTP
+    port: 80
+    name: prod-web-gw
+    allowedRoutes:
+      namespaces:
+        from: Same
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: foo
+spec:
+  parentRefs:
+  - name: prod-web
+  rules:
+  - backendRefs:
+    - name: myapp-svc
+      port: 8443
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: BackendTLSPolicy
+metadata:
+  name: myapp-backend-tls
+spec:
+  targetRefs:
+  - group: ""
+    kind: Service
+    name: myapp-svc
+  validation:
+    caCertificateRefs:
+    - group: ""
+      kind: ConfigMap
+      name: backend-ca
+    hostname: myapp-svc.example.com
+```
+
+Check that the policy is accepted on the Gateway:
+
+```sh
+kubectl get backendtlspolicy myapp-backend-tls -o yaml
+```
+
+The ancestor status must show `Accepted=True` and `ResolvedRefs=True` for the
+Gateway. If `ca.crt` is missing or empty, `ResolvedRefs` is `False` with reason
+`InvalidCACertificateRef`, and the Gateway returns HTTP 503 for that backend.

--- a/docs/user/example/creating_gateway_http_route.md
+++ b/docs/user/example/creating_gateway_http_route.md
@@ -90,3 +90,6 @@ and test that works:
 $ curl 192.168.8.5/hostname
 myapp-7dcffbf547-9kl2d
 ```
+
+To make the Gateway connect to the Service over TLS, see
+[Securing backend TLS with BackendTLSPolicy](creating_gateway_backendtlspolicy.md).

--- a/docs/user/gateway/gatewayapi.md
+++ b/docs/user/gateway/gatewayapi.md
@@ -1,7 +1,13 @@
 ## Gateway API support
 
 This provider has support for the [Gateway API](https://gateway-api.sigs.k8s.io/).
-It implements the `Gateway` and `HTTPRoute` functionalities and passes the community conformance tests.
+It implements the `Gateway` and `HTTPRoute` functionalities and advertises those
+features on `GatewayClass`. The Gateway HTTP conformance suite runs against this class.
+
+`BackendTLSPolicy` is an Extended feature. The implementation covers the core of
+the API: TLS from the Gateway to a Service backend, hostname validation, and
+CA certificates from a ConfigMap `ca.crt` key. SAN validation
+(`BackendTLSPolicySANValidation`) and well-known public CAs are not supported.
 
 The Gateway API controller is enabled by default using the standard channel,
 but you can select the Gateway API release channel (standard/experimental) or just disable the feature completely

--- a/examples/gateway_backendtlspolicy.yaml
+++ b/examples/gateway_backendtlspolicy.yaml
@@ -1,0 +1,57 @@
+# Create the CA ConfigMap first. The backend must serve TLS for the hostname
+# in BackendTLSPolicy.spec.validation.hostname:
+#   kubectl create configmap backend-ca --from-file=ca.crt=ca.crt
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: prod-web
+spec:
+  gatewayClassName: cloud-provider-kind
+  listeners:
+  - protocol: HTTP
+    port: 80
+    name: prod-web-gw
+    allowedRoutes:
+      namespaces:
+        from: Same
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: foo
+spec:
+  parentRefs:
+  - name: prod-web
+  rules:
+  - backendRefs:
+    - name: myapp-svc
+      port: 8443
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: BackendTLSPolicy
+metadata:
+  name: myapp-backend-tls
+spec:
+  targetRefs:
+  - group: ""
+    kind: Service
+    name: myapp-svc
+  validation:
+    caCertificateRefs:
+    - group: ""
+      kind: ConfigMap
+      name: backend-ca
+    hostname: myapp-svc.example.com
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: myapp-svc
+spec:
+  type: ClusterIP
+  selector:
+    app: MyApp
+  ports:
+    - name: https
+      port: 8443
+      targetPort: 443

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -235,6 +235,7 @@ func startCloudControllerManager(ctx context.Context, clusterName string, config
 	nodesInformer := sharedInformers.Core().V1().Nodes()
 	namespacesInformer := sharedInformers.Core().V1().Namespaces()
 	secretsInformer := sharedInformers.Core().V1().Secrets()
+	configMapsInformer := sharedInformers.Core().V1().ConfigMaps()
 	ingressInformer := sharedInformers.Networking().V1().Ingresses()
 	ingressClassInformer := sharedInformers.Networking().V1().IngressClasses()
 
@@ -323,6 +324,7 @@ func startCloudControllerManager(ctx context.Context, clusterName string, config
 		httpRouteInformer := sharedGwInformers.Gateway().V1().HTTPRoutes()
 		grpcRouteInformer := sharedGwInformers.Gateway().V1().GRPCRoutes()
 		referenceGrantInformer := sharedGwInformers.Gateway().V1().ReferenceGrants()
+		backendTLSPolicyInformer := sharedGwInformers.Gateway().V1().BackendTLSPolicies()
 
 		gatewayController, err = gateway.New(
 			clusterName,
@@ -331,11 +333,13 @@ func startCloudControllerManager(ctx context.Context, clusterName string, config
 			namespacesInformer,
 			servicesInformer,
 			secretsInformer,
+			configMapsInformer,
 			gwClassInformer,
 			gwInformer,
 			httpRouteInformer,
 			grpcRouteInformer,
 			referenceGrantInformer,
+			backendTLSPolicyInformer,
 		)
 		if err != nil {
 			logger.Error(err, "Failed to start gateway controller")

--- a/pkg/gateway/backendtlspolicy.go
+++ b/pkg/gateway/backendtlspolicy.go
@@ -17,99 +17,591 @@ limitations under the License.
 package gateway
 
 import (
+	"bytes"
+	"context"
 	"fmt"
 	"sort"
+	"strings"
 
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	tlsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
+	matcherv3 "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	"google.golang.org/protobuf/types/known/anypb"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
-func (c *Controller) lookupBackendTLSPolicy(serviceNamespace, serviceName string) *gatewayv1.BackendTLSPolicy {
+const maxPolicyAncestors = 16
+
+// backendTLSError is returned when a BackendTLSPolicy cannot be applied.
+// The dataplane must fail the client with HTTP 5xx and must not use plaintext.
+type backendTLSError struct {
+	reason  gatewayv1.PolicyConditionReason
+	message string
+}
+
+func (e *backendTLSError) Error() string {
+	return e.message
+}
+
+func isBackendTLSError(err error) bool {
+	_, ok := err.(*backendTLSError)
+	return ok
+}
+
+func sortBackendTLSPolicies(policies []*gatewayv1.BackendTLSPolicy) {
+	sort.Slice(policies, func(i, j int) bool {
+		if !policies[i].CreationTimestamp.Equal(&policies[j].CreationTimestamp) {
+			return policies[i].CreationTimestamp.Before(&policies[j].CreationTimestamp)
+		}
+		keyI := policies[i].Namespace + "/" + policies[i].Name
+		keyJ := policies[j].Namespace + "/" + policies[j].Name
+		return keyI < keyJ
+	})
+}
+
+func isServiceTargetRef(ref gatewayv1.LocalPolicyTargetReferenceWithSectionName) bool {
+	if ref.Group != "" && ref.Group != "core" {
+		return false
+	}
+	return ref.Kind == "Service"
+}
+
+func targetRefSectionName(ref gatewayv1.LocalPolicyTargetReferenceWithSectionName) string {
+	if ref.SectionName == nil {
+		return ""
+	}
+	return string(*ref.SectionName)
+}
+
+func policyConflictKey(namespace string, ref gatewayv1.LocalPolicyTargetReferenceWithSectionName) string {
+	return namespace + "/" + string(ref.Group) + "/" + string(ref.Kind) + "/" + string(ref.Name) + "/" + targetRefSectionName(ref)
+}
+
+// lookupBackendTLSPolicy returns the BackendTLSPolicy that applies to the
+// Service and port. A policy with a matching sectionName (Service port name)
+// takes precedence over a policy that targets the whole Service.
+// On ties, the oldest policy wins, then {namespace}/{name} in alphabetical order.
+func (c *Controller) lookupBackendTLSPolicy(serviceNamespace, serviceName, portName string) *gatewayv1.BackendTLSPolicy {
 	policies, err := c.backendTLSPolicyLister.BackendTLSPolicies(serviceNamespace).List(labels.Everything())
 	if err != nil {
 		klog.Errorf("Failed to list BackendTLSPolicies in namespace %s: %v", serviceNamespace, err)
 		return nil
 	}
 
-	var matching []*gatewayv1.BackendTLSPolicy
+	var specific, whole []*gatewayv1.BackendTLSPolicy
 	for _, policy := range policies {
-		for _, targetRef := range policy.Spec.TargetRefs {
-			if targetRef.Group != "" || targetRef.Kind != "Service" {
-				continue
-			}
-			if string(targetRef.Name) == serviceName {
-				matching = append(matching, policy)
-				break
-			}
+		matches, isSpecific := policyMatchesPort(policy, serviceName, portName)
+		if !matches {
+			continue
+		}
+		if isSpecific {
+			specific = append(specific, policy)
+		} else {
+			whole = append(whole, policy)
 		}
 	}
 
-	if len(matching) == 0 {
+	candidates := whole
+	if len(specific) > 0 {
+		candidates = specific
+	}
+	if len(candidates) == 0 {
 		return nil
 	}
-
-	sort.Slice(matching, func(i, j int) bool {
-		if !matching[i].CreationTimestamp.Equal(&matching[j].CreationTimestamp) {
-			return matching[i].CreationTimestamp.Before(&matching[j].CreationTimestamp)
-		}
-		keyI := matching[i].Namespace + "/" + matching[i].Name
-		keyJ := matching[j].Namespace + "/" + matching[j].Name
-		return keyI < keyJ
-	})
-
-	return matching[0]
+	sortBackendTLSPolicies(candidates)
+	return candidates[0]
 }
 
-func (c *Controller) buildUpstreamTLSContext(policy *gatewayv1.BackendTLSPolicy) (*anypb.Any, error) {
-	if len(policy.Spec.Validation.CACertificateRefs) == 0 {
-		return nil, fmt.Errorf("no CACertificateRefs in BackendTLSPolicy %s/%s", policy.Namespace, policy.Name)
+// policyMatchesPort reports whether the policy targets the Service and whether
+// that match is sectionName-specific for portName.
+func policyMatchesPort(policy *gatewayv1.BackendTLSPolicy, serviceName, portName string) (matches bool, specific bool) {
+	for _, ref := range policy.Spec.TargetRefs {
+		if !isServiceTargetRef(ref) || string(ref.Name) != serviceName {
+			continue
+		}
+		section := targetRefSectionName(ref)
+		if section == "" {
+			matches = true
+			continue
+		}
+		if portName != "" && section == portName {
+			return true, true
+		}
+	}
+	return matches, false
+}
+
+func servicePortName(service *corev1.Service, backendRef gatewayv1.BackendRef) string {
+	if backendRef.Port == nil {
+		return ""
+	}
+	want := int32(*backendRef.Port)
+	for _, p := range service.Spec.Ports {
+		if p.Port == want {
+			return p.Name
+		}
+	}
+	return ""
+}
+
+func (c *Controller) resolveCACertificate(policy *gatewayv1.BackendTLSPolicy) (*corev3.DataSource, error) {
+	if policy.Spec.Validation.WellKnownCACertificates != nil && *policy.Spec.Validation.WellKnownCACertificates != "" {
+		return nil, &backendTLSError{
+			reason:  gatewayv1.PolicyReasonInvalid,
+			message: fmt.Sprintf("WellKnownCACertificates is not supported in BackendTLSPolicy %s/%s", policy.Namespace, policy.Name),
+		}
 	}
 
-	caRef := policy.Spec.Validation.CACertificateRefs[0]
-
-	if string(caRef.Group) != "" {
-		return nil, fmt.Errorf("unsupported CACertificateRef group %q in BackendTLSPolicy %s/%s", caRef.Group, policy.Namespace, policy.Name)
-	}
-	if string(caRef.Kind) != "ConfigMap" {
-		return nil, fmt.Errorf("unsupported CACertificateRef kind %q in BackendTLSPolicy %s/%s (only ConfigMap is supported)", caRef.Kind, policy.Namespace, policy.Name)
-	}
-
-	cm, err := c.configMapLister.ConfigMaps(policy.Namespace).Get(string(caRef.Name))
-	if err != nil {
-		return nil, fmt.Errorf("failed to get ConfigMap %s/%s: %w", policy.Namespace, caRef.Name, err)
+	refs := policy.Spec.Validation.CACertificateRefs
+	if len(refs) == 0 {
+		return nil, &backendTLSError{
+			reason:  gatewayv1.BackendTLSPolicyReasonNoValidCACertificate,
+			message: fmt.Sprintf("no CACertificateRefs in BackendTLSPolicy %s/%s", policy.Namespace, policy.Name),
+		}
 	}
 
+	var lastErr error
+	validCount := 0
 	var trustedCA *corev3.DataSource
+	for _, ref := range refs {
+		ds, err := c.loadCACertificateRef(policy, ref)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		validCount++
+		if trustedCA == nil {
+			trustedCA = ds
+		}
+	}
+	if validCount == 0 {
+		if lastErr != nil {
+			return nil, lastErr
+		}
+		return nil, &backendTLSError{
+			reason:  gatewayv1.BackendTLSPolicyReasonNoValidCACertificate,
+			message: fmt.Sprintf("no valid CACertificateRefs in BackendTLSPolicy %s/%s", policy.Namespace, policy.Name),
+		}
+	}
+	if lastErr != nil {
+		// At least one ref is invalid. Fail the connection (no plaintext fallback).
+		return nil, lastErr
+	}
+	return trustedCA, nil
+}
+
+func (c *Controller) loadCACertificateRef(policy *gatewayv1.BackendTLSPolicy, ref gatewayv1.LocalObjectReference) (*corev3.DataSource, error) {
+	if string(ref.Group) != "" && string(ref.Group) != "core" {
+		return nil, &backendTLSError{
+			reason:  gatewayv1.BackendTLSPolicyReasonInvalidKind,
+			message: fmt.Sprintf("unsupported CACertificateRef group %q in BackendTLSPolicy %s/%s", ref.Group, policy.Namespace, policy.Name),
+		}
+	}
+	if string(ref.Kind) != "ConfigMap" {
+		return nil, &backendTLSError{
+			reason:  gatewayv1.BackendTLSPolicyReasonInvalidKind,
+			message: fmt.Sprintf("unsupported CACertificateRef kind %q in BackendTLSPolicy %s/%s (only ConfigMap is supported)", ref.Kind, policy.Namespace, policy.Name),
+		}
+	}
+
+	cm, err := c.configMapLister.ConfigMaps(policy.Namespace).Get(string(ref.Name))
+	if err != nil {
+		return nil, &backendTLSError{
+			reason:  gatewayv1.BackendTLSPolicyReasonInvalidCACertificateRef,
+			message: fmt.Sprintf("failed to get ConfigMap %s/%s: %v", policy.Namespace, ref.Name, err),
+		}
+	}
+
+	trustedCA, err := caCertFromConfigMap(cm)
+	if err != nil {
+		return nil, &backendTLSError{
+			reason:  gatewayv1.BackendTLSPolicyReasonInvalidCACertificateRef,
+			message: fmt.Sprintf("ConfigMap %s/%s: %v", policy.Namespace, ref.Name, err),
+		}
+	}
+	return trustedCA, nil
+}
+
+func caCertFromConfigMap(cm *corev1.ConfigMap) (*corev3.DataSource, error) {
 	if caCert, ok := cm.Data["ca.crt"]; ok {
-		trustedCA = &corev3.DataSource{
+		if strings.TrimSpace(caCert) == "" {
+			return nil, fmt.Errorf("key 'ca.crt' is empty")
+		}
+		return &corev3.DataSource{
 			Specifier: &corev3.DataSource_InlineString{
 				InlineString: caCert,
 			},
+		}, nil
+	}
+	if caCertBytes, ok := cm.BinaryData["ca.crt"]; ok {
+		if len(bytes.TrimSpace(caCertBytes)) == 0 {
+			return nil, fmt.Errorf("key 'ca.crt' is empty")
 		}
-	} else if caCertBytes, ok := cm.BinaryData["ca.crt"]; ok {
-		trustedCA = &corev3.DataSource{
+		return &corev3.DataSource{
 			Specifier: &corev3.DataSource_InlineBytes{
 				InlineBytes: caCertBytes,
 			},
-		}
-	} else {
-		return nil, fmt.Errorf("ConfigMap %s/%s does not contain key 'ca.crt'", policy.Namespace, caRef.Name)
+		}, nil
+	}
+	return nil, fmt.Errorf("does not contain key 'ca.crt'")
+}
+
+func (c *Controller) buildUpstreamTLSContext(policy *gatewayv1.BackendTLSPolicy) (*anypb.Any, error) {
+	trustedCA, err := c.resolveCACertificate(policy)
+	if err != nil {
+		return nil, err
 	}
 
+	hostname := string(policy.Spec.Validation.Hostname)
 	upstreamTLS := &tlsv3.UpstreamTlsContext{
-		Sni: string(policy.Spec.Validation.Hostname),
+		Sni: hostname,
 		CommonTlsContext: &tlsv3.CommonTlsContext{
 			ValidationContextType: &tlsv3.CommonTlsContext_ValidationContext{
 				ValidationContext: &tlsv3.CertificateValidationContext{
 					TrustedCa: trustedCA,
+					// Hostname is SNI and the certificate identity. Envoy does not
+					// authenticate the hostname from SNI plus TrustedCa alone.
+					MatchTypedSubjectAltNames: []*tlsv3.SubjectAltNameMatcher{{
+						SanType: tlsv3.SubjectAltNameMatcher_DNS,
+						Matcher: &matcherv3.StringMatcher{
+							MatchPattern: &matcherv3.StringMatcher_Exact{
+								Exact: hostname,
+							},
+						},
+					}},
 				},
 			},
 		},
 	}
 
 	return anypb.New(upstreamTLS)
+}
+
+// rewriteRoutesForInvalidBackendTLS replaces cluster routing with HTTP 503
+// when the BackendTLSPolicy CA is invalid. The spec requires HTTP 5xx and
+// forbids a plaintext fallback.
+func rewriteRoutesForInvalidBackendTLS(routes []*routev3.Route, invalidClusters map[string]struct{}) {
+	if len(invalidClusters) == 0 {
+		return
+	}
+	for _, route := range routes {
+		if routeUsesAnyCluster(route, invalidClusters) {
+			route.Action = &routev3.Route_DirectResponse{
+				DirectResponse: &routev3.DirectResponseAction{Status: 503},
+			}
+		}
+	}
+}
+
+func routeUsesAnyCluster(route *routev3.Route, clusters map[string]struct{}) bool {
+	action, ok := route.GetAction().(*routev3.Route_Route)
+	if !ok || action.Route == nil {
+		return false
+	}
+	switch spec := action.Route.ClusterSpecifier.(type) {
+	case *routev3.RouteAction_Cluster:
+		_, found := clusters[spec.Cluster]
+		return found
+	case *routev3.RouteAction_WeightedClusters:
+		if spec.WeightedClusters == nil {
+			return false
+		}
+		for _, w := range spec.WeightedClusters.Clusters {
+			if _, found := clusters[w.Name]; found {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (c *Controller) conflictWinners() map[string]*gatewayv1.BackendTLSPolicy {
+	winners := make(map[string]*gatewayv1.BackendTLSPolicy)
+	policies, err := c.backendTLSPolicyLister.List(labels.Everything())
+	if err != nil {
+		klog.Errorf("Failed to list BackendTLSPolicies: %v", err)
+		return winners
+	}
+	grouped := make(map[string][]*gatewayv1.BackendTLSPolicy)
+	for _, policy := range policies {
+		for _, ref := range policy.Spec.TargetRefs {
+			if !isServiceTargetRef(ref) {
+				continue
+			}
+			key := policyConflictKey(policy.Namespace, ref)
+			grouped[key] = append(grouped[key], policy)
+		}
+	}
+	for key, group := range grouped {
+		sortBackendTLSPolicies(group)
+		winners[key] = group[0]
+	}
+	return winners
+}
+
+func policyIsConflicted(policy *gatewayv1.BackendTLSPolicy, winners map[string]*gatewayv1.BackendTLSPolicy) bool {
+	for _, ref := range policy.Spec.TargetRefs {
+		if !isServiceTargetRef(ref) {
+			continue
+		}
+		winner := winners[policyConflictKey(policy.Namespace, ref)]
+		if winner != nil && (winner.Namespace != policy.Namespace || winner.Name != policy.Name) {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *Controller) servicesUsedByGateway(gw *gatewayv1.Gateway) map[string]struct{} {
+	used := make(map[string]struct{})
+	for _, route := range c.getHTTPRoutesForGateway(gw) {
+		for _, rule := range route.Spec.Rules {
+			for _, backendRef := range rule.BackendRefs {
+				if backendRef.Kind != nil && *backendRef.Kind != "Service" {
+					continue
+				}
+				if backendRef.Group != nil && *backendRef.Group != "" {
+					continue
+				}
+				ns := route.Namespace
+				if backendRef.Namespace != nil {
+					ns = string(*backendRef.Namespace)
+				}
+				used[ns+"/"+string(backendRef.Name)] = struct{}{}
+			}
+		}
+	}
+	return used
+}
+
+func policyTargetsUsedService(policy *gatewayv1.BackendTLSPolicy, used map[string]struct{}) bool {
+	for _, ref := range policy.Spec.TargetRefs {
+		if !isServiceTargetRef(ref) {
+			continue
+		}
+		if _, ok := used[policy.Namespace+"/"+string(ref.Name)]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *Controller) inspectTargetRefs(policy *gatewayv1.BackendTLSPolicy) *backendTLSError {
+	if c.serviceLister == nil {
+		return nil
+	}
+	for _, ref := range policy.Spec.TargetRefs {
+		if !isServiceTargetRef(ref) {
+			continue
+		}
+		svc, err := c.serviceLister.Services(policy.Namespace).Get(string(ref.Name))
+		if err != nil {
+			return &backendTLSError{
+				reason:  gatewayv1.PolicyReasonTargetNotFound,
+				message: fmt.Sprintf("Service %s/%s was not found", policy.Namespace, ref.Name),
+			}
+		}
+		section := targetRefSectionName(ref)
+		if section == "" {
+			continue
+		}
+		found := false
+		for _, p := range svc.Spec.Ports {
+			if p.Name == section {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return &backendTLSError{
+				reason:  gatewayv1.PolicyReasonTargetNotFound,
+				message: fmt.Sprintf("sectionName %q does not exist on Service %s/%s", section, policy.Namespace, ref.Name),
+			}
+		}
+	}
+	return nil
+}
+
+func backendTLSPolicyConditions(generation int64, conflicted bool, caErr *backendTLSError, targetErr *backendTLSError) []metav1.Condition {
+	now := metav1.Now()
+	accepted := metav1.Condition{
+		Type:               string(gatewayv1.PolicyConditionAccepted),
+		Status:             metav1.ConditionTrue,
+		Reason:             string(gatewayv1.PolicyReasonAccepted),
+		Message:            "Policy is accepted.",
+		ObservedGeneration: generation,
+		LastTransitionTime: now,
+	}
+	resolved := metav1.Condition{
+		Type:               string(gatewayv1.BackendTLSPolicyConditionResolvedRefs),
+		Status:             metav1.ConditionTrue,
+		Reason:             string(gatewayv1.BackendTLSPolicyReasonResolvedRefs),
+		Message:            "All object references were resolved.",
+		ObservedGeneration: generation,
+		LastTransitionTime: now,
+	}
+
+	if caErr != nil {
+		resolved.Status = metav1.ConditionFalse
+		resolved.Reason = string(caErr.reason)
+		resolved.Message = caErr.message
+		if caErr.reason == gatewayv1.BackendTLSPolicyReasonInvalidKind ||
+			caErr.reason == gatewayv1.BackendTLSPolicyReasonInvalidCACertificateRef ||
+			caErr.reason == gatewayv1.BackendTLSPolicyReasonNoValidCACertificate {
+			accepted.Status = metav1.ConditionFalse
+			accepted.Reason = string(gatewayv1.BackendTLSPolicyReasonNoValidCACertificate)
+			accepted.Message = caErr.message
+		}
+		if caErr.reason == gatewayv1.PolicyReasonInvalid {
+			accepted.Status = metav1.ConditionFalse
+			accepted.Reason = string(gatewayv1.PolicyReasonInvalid)
+			accepted.Message = caErr.message
+		}
+	}
+
+	if targetErr != nil {
+		accepted.Status = metav1.ConditionFalse
+		accepted.Reason = string(targetErr.reason)
+		accepted.Message = targetErr.message
+		resolved.Status = metav1.ConditionFalse
+		resolved.Reason = string(targetErr.reason)
+		resolved.Message = targetErr.message
+	}
+
+	if conflicted {
+		accepted.Status = metav1.ConditionFalse
+		accepted.Reason = string(gatewayv1.PolicyReasonConflicted)
+		accepted.Message = "Policy conflicts with another BackendTLSPolicy that targets the same Service and sectionName."
+	}
+
+	return []metav1.Condition{accepted, resolved}
+}
+
+func gatewayAncestorRef(gw *gatewayv1.Gateway) gatewayv1.ParentReference {
+	return gatewayv1.ParentReference{
+		Group:     ptr.To(gatewayv1.Group(gatewayv1.GroupName)),
+		Kind:      ptr.To(gatewayv1.Kind("Gateway")),
+		Namespace: ptr.To(gatewayv1.Namespace(gw.Namespace)),
+		Name:      gatewayv1.ObjectName(gw.Name),
+	}
+}
+
+func parentRefKey(ref gatewayv1.ParentReference) string {
+	ns := ""
+	if ref.Namespace != nil {
+		ns = string(*ref.Namespace)
+	}
+	kind := ""
+	if ref.Kind != nil {
+		kind = string(*ref.Kind)
+	}
+	return kind + "/" + ns + "/" + string(ref.Name)
+}
+
+func upsertPolicyAncestor(status *gatewayv1.PolicyStatus, ancestor gatewayv1.PolicyAncestorStatus) {
+	for i := range status.Ancestors {
+		existing := status.Ancestors[i]
+		if existing.ControllerName == ancestor.ControllerName &&
+			parentRefKey(existing.AncestorRef) == parentRefKey(ancestor.AncestorRef) {
+			merged := existing.Conditions
+			for _, cond := range ancestor.Conditions {
+				meta.SetStatusCondition(&merged, cond)
+			}
+			ancestor.Conditions = merged
+			status.Ancestors[i] = ancestor
+			return
+		}
+	}
+	if len(status.Ancestors) >= maxPolicyAncestors {
+		return
+	}
+	status.Ancestors = append(status.Ancestors, ancestor)
+}
+
+func removePolicyAncestor(status *gatewayv1.PolicyStatus, controller gatewayv1.GatewayController, ref gatewayv1.ParentReference) {
+	kept := make([]gatewayv1.PolicyAncestorStatus, 0, len(status.Ancestors))
+	for _, ancestor := range status.Ancestors {
+		if ancestor.ControllerName == controller && parentRefKey(ancestor.AncestorRef) == parentRefKey(ref) {
+			continue
+		}
+		kept = append(kept, ancestor)
+	}
+	status.Ancestors = kept
+}
+
+func (c *Controller) updateBackendTLSPolicyStatuses(ctx context.Context, gw *gatewayv1.Gateway) error {
+	if c.gwClient == nil || c.backendTLSPolicyLister == nil {
+		return nil
+	}
+
+	policies, err := c.backendTLSPolicyLister.List(labels.Everything())
+	if err != nil {
+		return fmt.Errorf("failed to list BackendTLSPolicies: %w", err)
+	}
+
+	used := c.servicesUsedByGateway(gw)
+	winners := c.conflictWinners()
+	ancestorRef := gatewayAncestorRef(gw)
+	var errs []error
+
+	for _, policy := range policies {
+		relevant := policyTargetsUsedService(policy, used)
+		updateErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			current, err := c.backendTLSPolicyLister.BackendTLSPolicies(policy.Namespace).Get(policy.Name)
+			if err != nil {
+				return err
+			}
+			updated := current.DeepCopy()
+			if !relevant {
+				before := len(updated.Status.Ancestors)
+				removePolicyAncestor(&updated.Status, gatewayv1.GatewayController(controllerName), ancestorRef)
+				if len(updated.Status.Ancestors) == before {
+					return nil
+				}
+			} else {
+				conflicted := policyIsConflicted(current, winners)
+				_, caErr := c.resolveCACertificate(current)
+				var tlsErr *backendTLSError
+				if caErr != nil {
+					var ok bool
+					tlsErr, ok = caErr.(*backendTLSError)
+					if !ok {
+						tlsErr = &backendTLSError{
+							reason:  gatewayv1.BackendTLSPolicyReasonInvalidCACertificateRef,
+							message: caErr.Error(),
+						}
+					}
+				}
+				targetErr := c.inspectTargetRefs(current)
+				conditions := backendTLSPolicyConditions(current.Generation, conflicted, tlsErr, targetErr)
+				upsertPolicyAncestor(&updated.Status, gatewayv1.PolicyAncestorStatus{
+					AncestorRef:    ancestorRef,
+					ControllerName: gatewayv1.GatewayController(controllerName),
+					Conditions:     conditions,
+				})
+			}
+
+			if semanticIgnoreLastTransitionTime.DeepEqual(current.Status, updated.Status) {
+				return nil
+			}
+			_, err = c.gwClient.GatewayV1().BackendTLSPolicies(updated.Namespace).UpdateStatus(ctx, updated, metav1.UpdateOptions{})
+			return err
+		})
+		if updateErr != nil {
+			errs = append(errs, fmt.Errorf("failed to update status for BackendTLSPolicy %s/%s: %w", policy.Namespace, policy.Name, updateErr))
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("backend TLS policy status updates: %v", errs)
+	}
+	return nil
 }

--- a/pkg/gateway/backendtlspolicy.go
+++ b/pkg/gateway/backendtlspolicy.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gateway
+
+import (
+	"fmt"
+	"sort"
+
+	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	tlsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
+	"google.golang.org/protobuf/types/known/anypb"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/klog/v2"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func (c *Controller) lookupBackendTLSPolicy(serviceNamespace, serviceName string) *gatewayv1.BackendTLSPolicy {
+	policies, err := c.backendTLSPolicyLister.BackendTLSPolicies(serviceNamespace).List(labels.Everything())
+	if err != nil {
+		klog.Errorf("Failed to list BackendTLSPolicies in namespace %s: %v", serviceNamespace, err)
+		return nil
+	}
+
+	var matching []*gatewayv1.BackendTLSPolicy
+	for _, policy := range policies {
+		for _, targetRef := range policy.Spec.TargetRefs {
+			if targetRef.Group != "" || targetRef.Kind != "Service" {
+				continue
+			}
+			if string(targetRef.Name) == serviceName {
+				matching = append(matching, policy)
+				break
+			}
+		}
+	}
+
+	if len(matching) == 0 {
+		return nil
+	}
+
+	sort.Slice(matching, func(i, j int) bool {
+		if !matching[i].CreationTimestamp.Equal(&matching[j].CreationTimestamp) {
+			return matching[i].CreationTimestamp.Before(&matching[j].CreationTimestamp)
+		}
+		keyI := matching[i].Namespace + "/" + matching[i].Name
+		keyJ := matching[j].Namespace + "/" + matching[j].Name
+		return keyI < keyJ
+	})
+
+	return matching[0]
+}
+
+func (c *Controller) buildUpstreamTLSContext(policy *gatewayv1.BackendTLSPolicy) (*anypb.Any, error) {
+	if len(policy.Spec.Validation.CACertificateRefs) == 0 {
+		return nil, fmt.Errorf("no CACertificateRefs in BackendTLSPolicy %s/%s", policy.Namespace, policy.Name)
+	}
+
+	caRef := policy.Spec.Validation.CACertificateRefs[0]
+
+	if string(caRef.Group) != "" {
+		return nil, fmt.Errorf("unsupported CACertificateRef group %q in BackendTLSPolicy %s/%s", caRef.Group, policy.Namespace, policy.Name)
+	}
+	if string(caRef.Kind) != "ConfigMap" {
+		return nil, fmt.Errorf("unsupported CACertificateRef kind %q in BackendTLSPolicy %s/%s (only ConfigMap is supported)", caRef.Kind, policy.Namespace, policy.Name)
+	}
+
+	cm, err := c.configMapLister.ConfigMaps(policy.Namespace).Get(string(caRef.Name))
+	if err != nil {
+		return nil, fmt.Errorf("failed to get ConfigMap %s/%s: %w", policy.Namespace, caRef.Name, err)
+	}
+
+	var trustedCA *corev3.DataSource
+	if caCert, ok := cm.Data["ca.crt"]; ok {
+		trustedCA = &corev3.DataSource{
+			Specifier: &corev3.DataSource_InlineString{
+				InlineString: caCert,
+			},
+		}
+	} else if caCertBytes, ok := cm.BinaryData["ca.crt"]; ok {
+		trustedCA = &corev3.DataSource{
+			Specifier: &corev3.DataSource_InlineBytes{
+				InlineBytes: caCertBytes,
+			},
+		}
+	} else {
+		return nil, fmt.Errorf("ConfigMap %s/%s does not contain key 'ca.crt'", policy.Namespace, caRef.Name)
+	}
+
+	upstreamTLS := &tlsv3.UpstreamTlsContext{
+		Sni: string(policy.Spec.Validation.Hostname),
+		CommonTlsContext: &tlsv3.CommonTlsContext{
+			ValidationContextType: &tlsv3.CommonTlsContext_ValidationContext{
+				ValidationContext: &tlsv3.CertificateValidationContext{
+					TrustedCa: trustedCA,
+				},
+			},
+		},
+	}
+
+	return anypb.New(upstreamTLS)
+}

--- a/pkg/gateway/backendtlspolicy.go
+++ b/pkg/gateway/backendtlspolicy.go
@@ -29,6 +29,7 @@ import (
 	matcherv3 "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	"google.golang.org/protobuf/types/known/anypb"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -54,6 +55,17 @@ func (e *backendTLSError) Error() string {
 func isBackendTLSError(err error) bool {
 	_, ok := err.(*backendTLSError)
 	return ok
+}
+
+// backendTLSPolicySpecChanged reports whether a policy update changed the spec.
+// Status-only updates must not enqueue Gateways or they starve listener programming.
+func backendTLSPolicySpecChanged(oldObj, newObj interface{}) bool {
+	oldPolicy, okOld := oldObj.(*gatewayv1.BackendTLSPolicy)
+	newPolicy, okNew := newObj.(*gatewayv1.BackendTLSPolicy)
+	if !okOld || !okNew {
+		return true
+	}
+	return oldPolicy.Generation != newPolicy.Generation
 }
 
 func sortBackendTLSPolicies(policies []*gatewayv1.BackendTLSPolicy) {
@@ -550,12 +562,15 @@ func (c *Controller) updateBackendTLSPolicyStatuses(ctx context.Context, gw *gat
 	used := c.servicesUsedByGateway(gw)
 	winners := c.conflictWinners()
 	ancestorRef := gatewayAncestorRef(gw)
-	var errs []error
 
 	for _, policy := range policies {
 		relevant := policyTargetsUsedService(policy, used)
 		updateErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-			current, err := c.backendTLSPolicyLister.BackendTLSPolicies(policy.Namespace).Get(policy.Name)
+			// Read from the API so a conflict retry uses a fresh resourceVersion.
+			current, err := c.gwClient.GatewayV1().BackendTLSPolicies(policy.Namespace).Get(ctx, policy.Name, metav1.GetOptions{})
+			if apierrors.IsNotFound(err) {
+				return nil
+			}
 			if err != nil {
 				return err
 			}
@@ -596,12 +611,10 @@ func (c *Controller) updateBackendTLSPolicyStatuses(ctx context.Context, gw *gat
 			return err
 		})
 		if updateErr != nil {
-			errs = append(errs, fmt.Errorf("failed to update status for BackendTLSPolicy %s/%s: %w", policy.Namespace, policy.Name, updateErr))
+			// Do not fail Gateway sync. A status conflict must not block
+			// listener programming for other Gateways.
+			klog.Errorf("failed to update status for BackendTLSPolicy %s/%s: %v", policy.Namespace, policy.Name, updateErr)
 		}
-	}
-
-	if len(errs) > 0 {
-		return fmt.Errorf("backend TLS policy status updates: %v", errs)
 	}
 	return nil
 }

--- a/pkg/gateway/backendtlspolicy_test.go
+++ b/pkg/gateway/backendtlspolicy_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 	"time"
 
+	routev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	tlsv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -138,6 +140,13 @@ func makeBackendTLSPolicy(namespace, name, serviceName, hostname string, created
 	}
 }
 
+func makeBackendTLSPolicyWithSection(namespace, name, serviceName, sectionName, hostname string, createdAt time.Time) *gatewayv1.BackendTLSPolicy {
+	policy := makeBackendTLSPolicy(namespace, name, serviceName, hostname, createdAt)
+	section := gatewayv1.SectionName(sectionName)
+	policy.Spec.TargetRefs[0].SectionName = &section
+	return policy
+}
+
 func TestLookupBackendTLSPolicy(t *testing.T) {
 	now := time.Now()
 
@@ -146,6 +155,7 @@ func TestLookupBackendTLSPolicy(t *testing.T) {
 		policies         []*gatewayv1.BackendTLSPolicy
 		serviceNamespace string
 		serviceName      string
+		portName         string
 		wantPolicyName   string
 	}{
 		{
@@ -224,6 +234,38 @@ func TestLookupBackendTLSPolicy(t *testing.T) {
 			serviceName:      "my-svc",
 			wantPolicyName:   "",
 		},
+		{
+			name: "sectionName match takes precedence over whole-service policy",
+			policies: []*gatewayv1.BackendTLSPolicy{
+				makeBackendTLSPolicy("default", "policy-whole", "my-svc", "whole.example.com", now),
+				makeBackendTLSPolicyWithSection("default", "policy-https", "my-svc", "https", "https.example.com", now.Add(time.Minute)),
+			},
+			serviceNamespace: "default",
+			serviceName:      "my-svc",
+			portName:         "https",
+			wantPolicyName:   "policy-https",
+		},
+		{
+			name: "sectionName for a different port is ignored",
+			policies: []*gatewayv1.BackendTLSPolicy{
+				makeBackendTLSPolicyWithSection("default", "policy-https", "my-svc", "https", "https.example.com", now),
+			},
+			serviceNamespace: "default",
+			serviceName:      "my-svc",
+			portName:         "http",
+			wantPolicyName:   "",
+		},
+		{
+			name: "whole-service policy applies when sectionName does not match",
+			policies: []*gatewayv1.BackendTLSPolicy{
+				makeBackendTLSPolicy("default", "policy-whole", "my-svc", "whole.example.com", now),
+				makeBackendTLSPolicyWithSection("default", "policy-https", "my-svc", "https", "https.example.com", now),
+			},
+			serviceNamespace: "default",
+			serviceName:      "my-svc",
+			portName:         "http",
+			wantPolicyName:   "policy-whole",
+		},
 	}
 
 	for _, tt := range tests {
@@ -231,7 +273,7 @@ func TestLookupBackendTLSPolicy(t *testing.T) {
 			c := &Controller{
 				backendTLSPolicyLister: &fakeBackendTLSPolicyLister{policies: tt.policies},
 			}
-			got := c.lookupBackendTLSPolicy(tt.serviceNamespace, tt.serviceName)
+			got := c.lookupBackendTLSPolicy(tt.serviceNamespace, tt.serviceName, tt.portName)
 			if tt.wantPolicyName == "" {
 				if got != nil {
 					t.Errorf("expected nil, got %s/%s", got.Namespace, got.Name)
@@ -289,6 +331,39 @@ func TestBuildUpstreamTLSContext(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name:   "ConfigMap with empty ca.crt in Data",
+			policy: makeBackendTLSPolicy("default", "policy-1", "my-svc", "my-svc.example.com", time.Now()),
+			configMaps: []*corev1.ConfigMap{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "ca-bundle"},
+					Data:       map[string]string{"ca.crt": ""},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name:   "ConfigMap with whitespace-only ca.crt in Data",
+			policy: makeBackendTLSPolicy("default", "policy-1", "my-svc", "my-svc.example.com", time.Now()),
+			configMaps: []*corev1.ConfigMap{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "ca-bundle"},
+					Data:       map[string]string{"ca.crt": "  \n"},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name:   "ConfigMap with empty ca.crt in BinaryData",
+			policy: makeBackendTLSPolicy("default", "policy-1", "my-svc", "my-svc.example.com", time.Now()),
+			configMaps: []*corev1.ConfigMap{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "ca-bundle"},
+					BinaryData: map[string][]byte{"ca.crt": {}},
+				},
+			},
+			wantErr: true,
+		},
+		{
 			name:       "ConfigMap does not exist",
 			policy:     makeBackendTLSPolicy("default", "policy-1", "my-svc", "my-svc.example.com", time.Now()),
 			configMaps: nil,
@@ -337,7 +412,136 @@ func TestBuildUpstreamTLSContext(t *testing.T) {
 			if !tt.wantErr && got == nil {
 				t.Error("buildUpstreamTLSContext() returned nil without error")
 			}
+			if !tt.wantErr && got != nil {
+				upstreamTLS := &tlsv3.UpstreamTlsContext{}
+				if err := got.UnmarshalTo(upstreamTLS); err != nil {
+					t.Fatalf("UnmarshalTo: %v", err)
+				}
+				hostname := string(tt.policy.Spec.Validation.Hostname)
+				if upstreamTLS.Sni != hostname {
+					t.Errorf("SNI = %q, want %q", upstreamTLS.Sni, hostname)
+				}
+				sans := upstreamTLS.GetCommonTlsContext().GetValidationContext().GetMatchTypedSubjectAltNames()
+				if len(sans) != 1 {
+					t.Fatalf("MatchTypedSubjectAltNames len = %d, want 1", len(sans))
+				}
+				if sans[0].GetSanType() != tlsv3.SubjectAltNameMatcher_DNS {
+					t.Errorf("SAN type = %v, want DNS", sans[0].GetSanType())
+				}
+				if sans[0].GetMatcher().GetExact() != hostname {
+					t.Errorf("SAN exact = %q, want %q", sans[0].GetMatcher().GetExact(), hostname)
+				}
+			}
 		})
+	}
+}
+
+func TestLoadCACertificateRefEmpty(t *testing.T) {
+	c := &Controller{
+		configMapLister: &fakeConfigMapLister{
+			configMaps: []*corev1.ConfigMap{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "ca-bundle"},
+					Data:       map[string]string{"ca.crt": ""},
+				},
+			},
+		},
+	}
+	policy := makeBackendTLSPolicy("default", "policy-1", "my-svc", "my-svc.example.com", time.Now())
+	_, err := c.loadCACertificateRef(policy, policy.Spec.Validation.CACertificateRefs[0])
+	if err == nil {
+		t.Fatal("expected error for empty ca.crt")
+	}
+	tlsErr, ok := err.(*backendTLSError)
+	if !ok {
+		t.Fatalf("error type = %T, want *backendTLSError", err)
+	}
+	if tlsErr.reason != gatewayv1.BackendTLSPolicyReasonInvalidCACertificateRef {
+		t.Errorf("reason = %q, want %q", tlsErr.reason, gatewayv1.BackendTLSPolicyReasonInvalidCACertificateRef)
+	}
+}
+
+func TestRewriteRoutesForInvalidBackendTLS(t *testing.T) {
+	routes := []*routev3.Route{
+		{
+			Name: "keep",
+			Action: &routev3.Route_Route{
+				Route: &routev3.RouteAction{
+					ClusterSpecifier: &routev3.RouteAction_Cluster{Cluster: "good-cluster"},
+				},
+			},
+		},
+		{
+			Name: "rewrite",
+			Action: &routev3.Route_Route{
+				Route: &routev3.RouteAction{
+					ClusterSpecifier: &routev3.RouteAction_Cluster{Cluster: "bad-cluster"},
+				},
+			},
+		},
+	}
+	rewriteRoutesForInvalidBackendTLS(routes, map[string]struct{}{"bad-cluster": {}})
+
+	if _, ok := routes[0].Action.(*routev3.Route_Route); !ok {
+		t.Errorf("route %q action was rewritten, want cluster route", routes[0].Name)
+	}
+	direct, ok := routes[1].Action.(*routev3.Route_DirectResponse)
+	if !ok {
+		t.Fatalf("route %q action type = %T, want DirectResponse", routes[1].Name, routes[1].Action)
+	}
+	if direct.DirectResponse.GetStatus() != 503 {
+		t.Errorf("DirectResponse status = %d, want 503", direct.DirectResponse.GetStatus())
+	}
+}
+
+func TestBackendTLSPolicyConditionsConflicted(t *testing.T) {
+	conds := backendTLSPolicyConditions(1, true, nil, nil)
+	var accepted *metav1.Condition
+	for i := range conds {
+		if conds[i].Type == string(gatewayv1.PolicyConditionAccepted) {
+			accepted = &conds[i]
+		}
+	}
+	if accepted == nil {
+		t.Fatal("Accepted condition is missing")
+	}
+	if accepted.Status != metav1.ConditionFalse {
+		t.Errorf("Accepted.Status = %s, want False", accepted.Status)
+	}
+	if accepted.Reason != string(gatewayv1.PolicyReasonConflicted) {
+		t.Errorf("Accepted.Reason = %q, want %q", accepted.Reason, gatewayv1.PolicyReasonConflicted)
+	}
+}
+
+func TestBackendTLSPolicyConditionsInvalidCA(t *testing.T) {
+	caErr := &backendTLSError{
+		reason:  gatewayv1.BackendTLSPolicyReasonInvalidCACertificateRef,
+		message: "ConfigMap default/ca-bundle does not contain key 'ca.crt'",
+	}
+	conds := backendTLSPolicyConditions(1, false, caErr, nil)
+	var accepted, resolved *metav1.Condition
+	for i := range conds {
+		switch conds[i].Type {
+		case string(gatewayv1.PolicyConditionAccepted):
+			accepted = &conds[i]
+		case string(gatewayv1.BackendTLSPolicyConditionResolvedRefs):
+			resolved = &conds[i]
+		}
+	}
+	if accepted == nil || resolved == nil {
+		t.Fatal("Accepted or ResolvedRefs condition is missing")
+	}
+	if accepted.Status != metav1.ConditionFalse {
+		t.Errorf("Accepted.Status = %s, want False", accepted.Status)
+	}
+	if accepted.Reason != string(gatewayv1.BackendTLSPolicyReasonNoValidCACertificate) {
+		t.Errorf("Accepted.Reason = %q, want %q", accepted.Reason, gatewayv1.BackendTLSPolicyReasonNoValidCACertificate)
+	}
+	if resolved.Status != metav1.ConditionFalse {
+		t.Errorf("ResolvedRefs.Status = %s, want False", resolved.Status)
+	}
+	if resolved.Reason != string(gatewayv1.BackendTLSPolicyReasonInvalidCACertificateRef) {
+		t.Errorf("ResolvedRefs.Reason = %q, want %q", resolved.Reason, gatewayv1.BackendTLSPolicyReasonInvalidCACertificateRef)
 	}
 }
 

--- a/pkg/gateway/backendtlspolicy_test.go
+++ b/pkg/gateway/backendtlspolicy_test.go
@@ -1,0 +1,436 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gateway
+
+import (
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewaylisters "sigs.k8s.io/gateway-api/pkg/client/listers/apis/v1"
+)
+
+type fakeBackendTLSPolicyLister struct {
+	policies []*gatewayv1.BackendTLSPolicy
+}
+
+func (f *fakeBackendTLSPolicyLister) List(selector labels.Selector) ([]*gatewayv1.BackendTLSPolicy, error) {
+	return f.policies, nil
+}
+
+func (f *fakeBackendTLSPolicyLister) Get(name string) (*gatewayv1.BackendTLSPolicy, error) {
+	for _, p := range f.policies {
+		if p.Name == name {
+			return p, nil
+		}
+	}
+	return nil, nil
+}
+
+func (f *fakeBackendTLSPolicyLister) BackendTLSPolicies(namespace string) gatewaylisters.BackendTLSPolicyNamespaceLister {
+	var filtered []*gatewayv1.BackendTLSPolicy
+	for _, p := range f.policies {
+		if p.Namespace == namespace {
+			filtered = append(filtered, p)
+		}
+	}
+	return &fakeBackendTLSPolicyLister{policies: filtered}
+}
+
+type fakeConfigMapLister struct {
+	configMaps []*corev1.ConfigMap
+}
+
+func (f *fakeConfigMapLister) List(selector labels.Selector) ([]*corev1.ConfigMap, error) {
+	return f.configMaps, nil
+}
+
+func (f *fakeConfigMapLister) Get(name string) (*corev1.ConfigMap, error) {
+	for _, cm := range f.configMaps {
+		if cm.Name == name {
+			return cm, nil
+		}
+	}
+	return nil, &notFoundError{name: name}
+}
+
+func (f *fakeConfigMapLister) ConfigMaps(namespace string) corev1listers.ConfigMapNamespaceLister {
+	var filtered []*corev1.ConfigMap
+	for _, cm := range f.configMaps {
+		if cm.Namespace == namespace {
+			filtered = append(filtered, cm)
+		}
+	}
+	return &fakeConfigMapNamespaceLister{configMaps: filtered}
+}
+
+type fakeConfigMapNamespaceLister struct {
+	configMaps []*corev1.ConfigMap
+}
+
+func (f *fakeConfigMapNamespaceLister) List(selector labels.Selector) ([]*corev1.ConfigMap, error) {
+	return f.configMaps, nil
+}
+
+func (f *fakeConfigMapNamespaceLister) Get(name string) (*corev1.ConfigMap, error) {
+	for _, cm := range f.configMaps {
+		if cm.Name == name {
+			return cm, nil
+		}
+	}
+	return nil, &notFoundError{name: name}
+}
+
+type notFoundError struct {
+	name string
+}
+
+func (e *notFoundError) Error() string {
+	return e.name + " not found"
+}
+
+func makeBackendTLSPolicy(namespace, name, serviceName, hostname string, createdAt time.Time) *gatewayv1.BackendTLSPolicy {
+	return &gatewayv1.BackendTLSPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:         namespace,
+			Name:              name,
+			CreationTimestamp: metav1.NewTime(createdAt),
+		},
+		Spec: gatewayv1.BackendTLSPolicySpec{
+			TargetRefs: []gatewayv1.LocalPolicyTargetReferenceWithSectionName{
+				{
+					LocalPolicyTargetReference: gatewayv1.LocalPolicyTargetReference{
+						Group: "",
+						Kind:  "Service",
+						Name:  gatewayv1.ObjectName(serviceName),
+					},
+				},
+			},
+			Validation: gatewayv1.BackendTLSPolicyValidation{
+				Hostname: gatewayv1.PreciseHostname(hostname),
+				CACertificateRefs: []gatewayv1.LocalObjectReference{
+					{
+						Group: "",
+						Kind:  "ConfigMap",
+						Name:  "ca-bundle",
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestLookupBackendTLSPolicy(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name             string
+		policies         []*gatewayv1.BackendTLSPolicy
+		serviceNamespace string
+		serviceName      string
+		wantPolicyName   string
+	}{
+		{
+			name:             "no policies",
+			policies:         nil,
+			serviceNamespace: "default",
+			serviceName:      "my-svc",
+			wantPolicyName:   "",
+		},
+		{
+			name: "single matching policy",
+			policies: []*gatewayv1.BackendTLSPolicy{
+				makeBackendTLSPolicy("default", "policy-1", "my-svc", "my-svc.example.com", now),
+			},
+			serviceNamespace: "default",
+			serviceName:      "my-svc",
+			wantPolicyName:   "policy-1",
+		},
+		{
+			name: "policy targets different service",
+			policies: []*gatewayv1.BackendTLSPolicy{
+				makeBackendTLSPolicy("default", "policy-1", "other-svc", "other.example.com", now),
+			},
+			serviceNamespace: "default",
+			serviceName:      "my-svc",
+			wantPolicyName:   "",
+		},
+		{
+			name: "policy in different namespace",
+			policies: []*gatewayv1.BackendTLSPolicy{
+				makeBackendTLSPolicy("other-ns", "policy-1", "my-svc", "my-svc.example.com", now),
+			},
+			serviceNamespace: "default",
+			serviceName:      "my-svc",
+			wantPolicyName:   "",
+		},
+		{
+			name: "multiple matching policies - oldest wins",
+			policies: []*gatewayv1.BackendTLSPolicy{
+				makeBackendTLSPolicy("default", "policy-newer", "my-svc", "my-svc.example.com", now.Add(time.Minute)),
+				makeBackendTLSPolicy("default", "policy-older", "my-svc", "my-svc.example.com", now),
+			},
+			serviceNamespace: "default",
+			serviceName:      "my-svc",
+			wantPolicyName:   "policy-older",
+		},
+		{
+			name: "multiple matching policies - same timestamp, alphabetical wins",
+			policies: []*gatewayv1.BackendTLSPolicy{
+				makeBackendTLSPolicy("default", "policy-b", "my-svc", "my-svc.example.com", now),
+				makeBackendTLSPolicy("default", "policy-a", "my-svc", "my-svc.example.com", now),
+			},
+			serviceNamespace: "default",
+			serviceName:      "my-svc",
+			wantPolicyName:   "policy-a",
+		},
+		{
+			name: "policy targets non-Service kind is ignored",
+			policies: []*gatewayv1.BackendTLSPolicy{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "policy-1"},
+					Spec: gatewayv1.BackendTLSPolicySpec{
+						TargetRefs: []gatewayv1.LocalPolicyTargetReferenceWithSectionName{
+							{
+								LocalPolicyTargetReference: gatewayv1.LocalPolicyTargetReference{
+									Group: "",
+									Kind:  "ServiceImport",
+									Name:  "my-svc",
+								},
+							},
+						},
+					},
+				},
+			},
+			serviceNamespace: "default",
+			serviceName:      "my-svc",
+			wantPolicyName:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Controller{
+				backendTLSPolicyLister: &fakeBackendTLSPolicyLister{policies: tt.policies},
+			}
+			got := c.lookupBackendTLSPolicy(tt.serviceNamespace, tt.serviceName)
+			if tt.wantPolicyName == "" {
+				if got != nil {
+					t.Errorf("expected nil, got %s/%s", got.Namespace, got.Name)
+				}
+			} else {
+				if got == nil {
+					t.Fatalf("expected policy %q, got nil", tt.wantPolicyName)
+				}
+				if got.Name != tt.wantPolicyName {
+					t.Errorf("expected policy %q, got %q", tt.wantPolicyName, got.Name)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildUpstreamTLSContext(t *testing.T) {
+	tests := []struct {
+		name       string
+		policy     *gatewayv1.BackendTLSPolicy
+		configMaps []*corev1.ConfigMap
+		wantErr    bool
+	}{
+		{
+			name:   "valid ConfigMap with ca.crt in Data",
+			policy: makeBackendTLSPolicy("default", "policy-1", "my-svc", "my-svc.example.com", time.Now()),
+			configMaps: []*corev1.ConfigMap{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "ca-bundle"},
+					Data:       map[string]string{"ca.crt": "-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----\n"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:   "valid ConfigMap with ca.crt in BinaryData",
+			policy: makeBackendTLSPolicy("default", "policy-1", "my-svc", "my-svc.example.com", time.Now()),
+			configMaps: []*corev1.ConfigMap{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "ca-bundle"},
+					BinaryData: map[string][]byte{"ca.crt": []byte("-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----\n")},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:   "ConfigMap missing ca.crt key",
+			policy: makeBackendTLSPolicy("default", "policy-1", "my-svc", "my-svc.example.com", time.Now()),
+			configMaps: []*corev1.ConfigMap{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "ca-bundle"},
+					Data:       map[string]string{"other-key": "value"},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name:       "ConfigMap does not exist",
+			policy:     makeBackendTLSPolicy("default", "policy-1", "my-svc", "my-svc.example.com", time.Now()),
+			configMaps: nil,
+			wantErr:    true,
+		},
+		{
+			name: "empty CACertificateRefs",
+			policy: &gatewayv1.BackendTLSPolicy{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "policy-1"},
+				Spec: gatewayv1.BackendTLSPolicySpec{
+					Validation: gatewayv1.BackendTLSPolicyValidation{
+						Hostname:          "my-svc.example.com",
+						CACertificateRefs: []gatewayv1.LocalObjectReference{},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "unsupported CACertificateRef kind",
+			policy: &gatewayv1.BackendTLSPolicy{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "policy-1"},
+				Spec: gatewayv1.BackendTLSPolicySpec{
+					Validation: gatewayv1.BackendTLSPolicyValidation{
+						Hostname: "my-svc.example.com",
+						CACertificateRefs: []gatewayv1.LocalObjectReference{
+							{Group: "", Kind: "Secret", Name: "my-secret"},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &Controller{
+				configMapLister: &fakeConfigMapLister{configMaps: tt.configMaps},
+			}
+			got, err := c.buildUpstreamTLSContext(tt.policy)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("buildUpstreamTLSContext() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got == nil {
+				t.Error("buildUpstreamTLSContext() returned nil without error")
+			}
+		})
+	}
+}
+
+func TestRouteReferencesService(t *testing.T) {
+	tests := []struct {
+		name             string
+		route            *gatewayv1.HTTPRoute
+		serviceName      string
+		serviceNamespace string
+		want             bool
+	}{
+		{
+			name: "route references the service",
+			route: &gatewayv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "default"},
+				Spec: gatewayv1.HTTPRouteSpec{
+					Rules: []gatewayv1.HTTPRouteRule{
+						{
+							BackendRefs: []gatewayv1.HTTPBackendRef{
+								{BackendRef: gatewayv1.BackendRef{
+									BackendObjectReference: gatewayv1.BackendObjectReference{
+										Name: "my-svc",
+										Port: ptrTo(gatewayv1.PortNumber(8080)),
+									},
+								}},
+							},
+						},
+					},
+				},
+			},
+			serviceName:      "my-svc",
+			serviceNamespace: "default",
+			want:             true,
+		},
+		{
+			name: "route references a different service",
+			route: &gatewayv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "default"},
+				Spec: gatewayv1.HTTPRouteSpec{
+					Rules: []gatewayv1.HTTPRouteRule{
+						{
+							BackendRefs: []gatewayv1.HTTPBackendRef{
+								{BackendRef: gatewayv1.BackendRef{
+									BackendObjectReference: gatewayv1.BackendObjectReference{
+										Name: "other-svc",
+										Port: ptrTo(gatewayv1.PortNumber(8080)),
+									},
+								}},
+							},
+						},
+					},
+				},
+			},
+			serviceName:      "my-svc",
+			serviceNamespace: "default",
+			want:             false,
+		},
+		{
+			name: "route in different namespace with explicit namespace ref",
+			route: &gatewayv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "route-ns"},
+				Spec: gatewayv1.HTTPRouteSpec{
+					Rules: []gatewayv1.HTTPRouteRule{
+						{
+							BackendRefs: []gatewayv1.HTTPBackendRef{
+								{BackendRef: gatewayv1.BackendRef{
+									BackendObjectReference: gatewayv1.BackendObjectReference{
+										Name:      "my-svc",
+										Namespace: ptrTo(gatewayv1.Namespace("default")),
+										Port:      ptrTo(gatewayv1.PortNumber(8080)),
+									},
+								}},
+							},
+						},
+					},
+				},
+			},
+			serviceName:      "my-svc",
+			serviceNamespace: "default",
+			want:             true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := routeReferencesService(tt.route, tt.serviceName, tt.serviceNamespace)
+			if got != tt.want {
+				t.Errorf("routeReferencesService() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func ptrTo[T any](v T) *T {
+	return &v
+}

--- a/pkg/gateway/backendtlspolicy_test.go
+++ b/pkg/gateway/backendtlspolicy_test.go
@@ -635,6 +635,28 @@ func TestRouteReferencesService(t *testing.T) {
 	}
 }
 
+func TestBackendTLSPolicySpecChanged(t *testing.T) {
+	base := makeBackendTLSPolicy("default", "policy-1", "my-svc", "my-svc.example.com", time.Now())
+	base.Generation = 1
+
+	statusOnly := base.DeepCopy()
+	statusOnly.Status.Ancestors = []gatewayv1.PolicyAncestorStatus{{}}
+
+	specChanged := base.DeepCopy()
+	specChanged.Generation = 2
+	specChanged.Spec.Validation.Hostname = "other.example.com"
+
+	if backendTLSPolicySpecChanged(base, statusOnly) {
+		t.Error("status-only update must not count as a spec change")
+	}
+	if !backendTLSPolicySpecChanged(base, specChanged) {
+		t.Error("generation change must count as a spec change")
+	}
+	if !backendTLSPolicySpecChanged(nil, base) {
+		t.Error("untyped or missing old object must count as a spec change")
+	}
+}
+
 func ptrTo[T any](v T) *T {
 	return &v
 }

--- a/pkg/gateway/controller.go
+++ b/pkg/gateway/controller.go
@@ -318,6 +318,7 @@ func New(
 	}
 
 	_, err = configMapInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    c.processConfigMapForTLSPolicy,
 		UpdateFunc: func(old, new interface{}) { c.processConfigMapForTLSPolicy(new) },
 		DeleteFunc: c.processConfigMapForTLSPolicy,
 	})

--- a/pkg/gateway/controller.go
+++ b/pkg/gateway/controller.go
@@ -309,8 +309,13 @@ func New(
 	}
 
 	_, err = backendTLSPolicyInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    c.processBackendTLSPolicy,
-		UpdateFunc: func(old, new interface{}) { c.processBackendTLSPolicy(new) },
+		AddFunc: c.processBackendTLSPolicy,
+		UpdateFunc: func(old, new interface{}) {
+			if !backendTLSPolicySpecChanged(old, new) {
+				return
+			}
+			c.processBackendTLSPolicy(new)
+		},
 		DeleteFunc: c.processBackendTLSPolicy,
 	})
 	if err != nil {
@@ -688,7 +693,7 @@ func (c *Controller) processBackendTLSPolicy(obj interface{}) {
 
 	gatewaysToEnqueue := make(map[string]struct{})
 	for _, targetRef := range policy.Spec.TargetRefs {
-		if targetRef.Group != "" || targetRef.Kind != "Service" {
+		if !isServiceTargetRef(targetRef) {
 			continue
 		}
 		serviceName := string(targetRef.Name)

--- a/pkg/gateway/controller.go
+++ b/pkg/gateway/controller.go
@@ -39,6 +39,7 @@ import (
 	cachev3 "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
 	resourcev3 "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
 	serverv3 "github.com/envoyproxy/go-control-plane/pkg/server/v3"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -101,6 +102,9 @@ type Controller struct {
 	secretLister       corev1listers.SecretLister
 	secretListerSynced cache.InformerSynced
 
+	configMapLister       corev1listers.ConfigMapLister
+	configMapListerSynced cache.InformerSynced
+
 	gatewayClassLister       gatewaylisters.GatewayClassLister
 	gatewayClassListerSynced cache.InformerSynced
 
@@ -116,6 +120,9 @@ type Controller struct {
 
 	referenceGrantLister       gatewaylisters.ReferenceGrantLister
 	referenceGrantListerSynced cache.InformerSynced
+
+	backendTLSPolicyLister       gatewaylisters.BackendTLSPolicyLister
+	backendTLSPolicyListerSynced cache.InformerSynced
 
 	xdscache        cachev3.SnapshotCache
 	xdsserver       serverv3.Server
@@ -133,11 +140,13 @@ func New(
 	namespaceInformer corev1informers.NamespaceInformer,
 	serviceInformer corev1informers.ServiceInformer,
 	secretInformer corev1informers.SecretInformer,
+	configMapInformer corev1informers.ConfigMapInformer,
 	gatewayClassInformer gatewayinformers.GatewayClassInformer,
 	gatewayInformer gatewayinformers.GatewayInformer,
 	httprouteInformer gatewayinformers.HTTPRouteInformer,
 	grpcrouteInformer gatewayinformers.GRPCRouteInformer,
 	referenceGrantInformer gatewayinformers.ReferenceGrantInformer,
+	backendTLSPolicyInformer gatewayinformers.BackendTLSPolicyInformer,
 ) (*Controller, error) {
 	c := &Controller{
 		clusterName:              clusterName,
@@ -148,6 +157,8 @@ func New(
 		serviceListerSynced:      serviceInformer.Informer().HasSynced,
 		secretLister:             secretInformer.Lister(),
 		secretListerSynced:       secretInformer.Informer().HasSynced,
+		configMapLister:          configMapInformer.Lister(),
+		configMapListerSynced:    configMapInformer.Informer().HasSynced,
 		gwClient:                 gwClient,
 		gatewayClassLister:       gatewayClassInformer.Lister(),
 		gatewayClassListerSynced: gatewayClassInformer.Informer().HasSynced,
@@ -157,12 +168,14 @@ func New(
 			workqueue.DefaultTypedControllerRateLimiter[string](),
 			workqueue.TypedRateLimitingQueueConfig[string]{Name: "gateway"},
 		),
-		httprouteLister:            httprouteInformer.Lister(),
-		httprouteListerSynced:      httprouteInformer.Informer().HasSynced,
-		grpcrouteLister:            grpcrouteInformer.Lister(),
-		grpcrouteListerSynced:      grpcrouteInformer.Informer().HasSynced,
-		referenceGrantLister:       referenceGrantInformer.Lister(),
-		referenceGrantListerSynced: referenceGrantInformer.Informer().HasSynced,
+		httprouteLister:              httprouteInformer.Lister(),
+		httprouteListerSynced:        httprouteInformer.Informer().HasSynced,
+		grpcrouteLister:              grpcrouteInformer.Lister(),
+		grpcrouteListerSynced:        grpcrouteInformer.Informer().HasSynced,
+		referenceGrantLister:         referenceGrantInformer.Lister(),
+		referenceGrantListerSynced:   referenceGrantInformer.Informer().HasSynced,
+		backendTLSPolicyLister:       backendTLSPolicyInformer.Lister(),
+		backendTLSPolicyListerSynced: backendTLSPolicyInformer.Informer().HasSynced,
 	}
 	_, err := gatewayClassInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
@@ -295,6 +308,23 @@ func New(
 		return nil, err
 	}
 
+	_, err = backendTLSPolicyInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    c.processBackendTLSPolicy,
+		UpdateFunc: func(old, new interface{}) { c.processBackendTLSPolicy(new) },
+		DeleteFunc: c.processBackendTLSPolicy,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = configMapInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		UpdateFunc: func(old, new interface{}) { c.processConfigMapForTLSPolicy(new) },
+		DeleteFunc: c.processConfigMapForTLSPolicy,
+	})
+	if err != nil {
+		return nil, err
+	}
+
 	if config.DefaultConfig.LoadBalancerConnectivity == config.Tunnel {
 		c.tunnelManager = tunnels.NewTunnelManager()
 	}
@@ -314,7 +344,9 @@ func (c *Controller) Init(ctx context.Context) error {
 		c.namespaceListerSynced,
 		c.serviceListerSynced,
 		c.secretListerSynced,
+		c.configMapListerSynced,
 		c.referenceGrantListerSynced,
+		c.backendTLSPolicyListerSynced,
 	) {
 		return fmt.Errorf("timed out waiting for caches to sync")
 	}
@@ -631,6 +663,152 @@ func gatewayReferencesSecretInNamespace(gateway *gatewayv1.Gateway, namespace st
 				secretNamespace = string(*certRef.Namespace)
 			}
 			if secretNamespace == namespace {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (c *Controller) processBackendTLSPolicy(obj interface{}) {
+	policy, ok := obj.(*gatewayv1.BackendTLSPolicy)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			runtime.HandleError(fmt.Errorf("error decoding BackendTLSPolicy, invalid type"))
+			return
+		}
+		policy, ok = tombstone.Obj.(*gatewayv1.BackendTLSPolicy)
+		if !ok {
+			runtime.HandleError(fmt.Errorf("error decoding BackendTLSPolicy tombstone, invalid type"))
+			return
+		}
+	}
+
+	gatewaysToEnqueue := make(map[string]struct{})
+	for _, targetRef := range policy.Spec.TargetRefs {
+		if targetRef.Group != "" || targetRef.Kind != "Service" {
+			continue
+		}
+		serviceName := string(targetRef.Name)
+
+		httpRoutes, err := c.httprouteLister.List(labels.Everything())
+		if err != nil {
+			klog.Errorf("Failed to list HTTPRoutes: %v", err)
+			continue
+		}
+		for _, route := range httpRoutes {
+			if routeReferencesService(route, serviceName, policy.Namespace) {
+				for _, parentRef := range route.Spec.ParentRefs {
+					if (parentRef.Group != nil && string(*parentRef.Group) != gatewayv1.GroupName) ||
+						(parentRef.Kind != nil && string(*parentRef.Kind) != "Gateway") {
+						continue
+					}
+					gwNamespace := route.Namespace
+					if parentRef.Namespace != nil {
+						gwNamespace = string(*parentRef.Namespace)
+					}
+					key := gwNamespace + "/" + string(parentRef.Name)
+					gatewaysToEnqueue[key] = struct{}{}
+				}
+			}
+		}
+
+		grpcRoutes, err := c.grpcrouteLister.List(labels.Everything())
+		if err != nil {
+			klog.Errorf("Failed to list GRPCRoutes: %v", err)
+			continue
+		}
+		for _, route := range grpcRoutes {
+			if grpcRouteReferencesService(route, serviceName, policy.Namespace) {
+				for _, parentRef := range route.Spec.ParentRefs {
+					if (parentRef.Group != nil && string(*parentRef.Group) != gatewayv1.GroupName) ||
+						(parentRef.Kind != nil && string(*parentRef.Kind) != "Gateway") {
+						continue
+					}
+					gwNamespace := route.Namespace
+					if parentRef.Namespace != nil {
+						gwNamespace = string(*parentRef.Namespace)
+					}
+					key := gwNamespace + "/" + string(parentRef.Name)
+					gatewaysToEnqueue[key] = struct{}{}
+				}
+			}
+		}
+	}
+
+	for key := range gatewaysToEnqueue {
+		c.gatewayqueue.Add(key)
+	}
+}
+
+func (c *Controller) processConfigMapForTLSPolicy(obj interface{}) {
+	cm, ok := obj.(*corev1.ConfigMap)
+	if !ok {
+		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
+		if !ok {
+			runtime.HandleError(fmt.Errorf("error decoding ConfigMap, invalid type"))
+			return
+		}
+		cm, ok = tombstone.Obj.(*corev1.ConfigMap)
+		if !ok {
+			runtime.HandleError(fmt.Errorf("error decoding ConfigMap tombstone, invalid type"))
+			return
+		}
+	}
+
+	policies, err := c.backendTLSPolicyLister.BackendTLSPolicies(cm.Namespace).List(labels.Everything())
+	if err != nil {
+		klog.Errorf("Failed to list BackendTLSPolicies in namespace %s: %v", cm.Namespace, err)
+		return
+	}
+	for _, policy := range policies {
+		for _, caRef := range policy.Spec.Validation.CACertificateRefs {
+			if (caRef.Group == "" || caRef.Group == "core") &&
+				caRef.Kind == "ConfigMap" &&
+				string(caRef.Name) == cm.Name {
+				c.processBackendTLSPolicy(policy)
+				break
+			}
+		}
+	}
+}
+
+func routeReferencesService(route *gatewayv1.HTTPRoute, serviceName, serviceNamespace string) bool {
+	for _, rule := range route.Spec.Rules {
+		for _, backendRef := range rule.BackendRefs {
+			if backendRef.Kind != nil && *backendRef.Kind != "Service" {
+				continue
+			}
+			if backendRef.Group != nil && *backendRef.Group != "" {
+				continue
+			}
+			refNamespace := route.Namespace
+			if backendRef.Namespace != nil {
+				refNamespace = string(*backendRef.Namespace)
+			}
+			if string(backendRef.Name) == serviceName && refNamespace == serviceNamespace {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func grpcRouteReferencesService(route *gatewayv1.GRPCRoute, serviceName, serviceNamespace string) bool {
+	for _, rule := range route.Spec.Rules {
+		for _, backendRef := range rule.BackendRefs {
+			if backendRef.Kind != nil && *backendRef.Kind != "Service" {
+				continue
+			}
+			if backendRef.Group != nil && *backendRef.Group != "" {
+				continue
+			}
+			refNamespace := route.Namespace
+			if backendRef.Namespace != nil {
+				refNamespace = string(*backendRef.Namespace)
+			}
+			if string(backendRef.Name) == serviceName && refNamespace == serviceNamespace {
 				return true
 			}
 		}

--- a/pkg/gateway/features.go
+++ b/pkg/gateway/features.go
@@ -31,6 +31,7 @@ var supportedFeatures = buildSupportedFeatures(
 	features.SupportHTTPRoute,
 	features.SupportReferenceGrant,
 	// Extended
+	features.SupportBackendTLSPolicy,
 	features.SupportGatewayAddressEmpty,
 	features.SupportGatewayPort8080,
 	features.SupportHTTPRoute303RedirectStatusCode,

--- a/pkg/gateway/features_test.go
+++ b/pkg/gateway/features_test.go
@@ -19,6 +19,7 @@ package gateway
 import (
 	"testing"
 
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	"sigs.k8s.io/gateway-api/pkg/features"
 )
 
@@ -46,6 +47,15 @@ func TestSupportedFeaturesContainsCore(t *testing.T) {
 			t.Errorf("core feature %q is missing from supportedFeatures", name)
 		}
 	}
+}
+
+func TestSupportedFeaturesContainsBackendTLSPolicy(t *testing.T) {
+	for _, f := range supportedFeatures {
+		if f.Name == gatewayv1.FeatureName(features.SupportBackendTLSPolicy) {
+			return
+		}
+	}
+	t.Error("BackendTLSPolicy is missing from supportedFeatures")
 }
 
 func TestBuildSupportedFeaturesSort(t *testing.T) {

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -161,7 +161,10 @@ func (c *Controller) syncGateway(ctx context.Context, key string) error {
 			return err
 		}
 	}
-	return c.updateRouteStatuses(ctx, httpRouteStatuses, grpcRouteStatuses)
+	if err := c.updateRouteStatuses(ctx, httpRouteStatuses, grpcRouteStatuses); err != nil {
+		return err
+	}
+	return c.updateBackendTLSPolicyStatuses(ctx, newGw)
 }
 
 // Main State Calculation Function
@@ -305,14 +308,23 @@ func (c *Controller) buildEnvoyResourcesForGateway(gateway *gatewayv1.Gateway) (
 					httpRouteStatuses[key] = currentParentStatuses
 
 					// Create the necessary Envoy Cluster resources from the valid backends.
+					invalidTLSClusters := map[string]struct{}{}
 					for _, backendRef := range validBackendRefs {
 						cluster, err := c.translateBackendRefToCluster(httpRoute.Namespace, backendRef)
+						if isBackendTLSError(err) {
+							name, nameErr := backendRefToClusterName(httpRoute.Namespace, backendRef)
+							if nameErr == nil {
+								invalidTLSClusters[name] = struct{}{}
+							}
+							continue
+						}
 						if err == nil && cluster != nil {
 							if _, exists := envoyClusters[cluster.Name]; !exists {
 								envoyClusters[cluster.Name] = cluster
 							}
 						}
 					}
+					rewriteRoutesForInvalidBackendTLS(routes, invalidTLSClusters)
 
 					// Aggregate Envoy routes into VirtualHosts.
 					if routes != nil {
@@ -736,11 +748,11 @@ func (c *Controller) translateBackendRefToCluster(defaultNamespace string, backe
 		cluster.LoadAssignment = createClusterLoadAssignment(clusterName, service.Spec.ClusterIP, uint32(*backendRef.Port))
 	}
 
-	if policy := c.lookupBackendTLSPolicy(ns, string(backendRef.Name)); policy != nil {
+	portName := servicePortName(service, backendRef)
+	if policy := c.lookupBackendTLSPolicy(ns, string(backendRef.Name), portName); policy != nil {
 		tlsContextAny, err := c.buildUpstreamTLSContext(policy)
 		if err != nil {
-			return nil, fmt.Errorf("invalid BackendTLSPolicy %s/%s for service %s/%s: %w",
-				policy.Namespace, policy.Name, ns, backendRef.Name, err)
+			return nil, err
 		}
 		cluster.TransportSocket = &corev3.TransportSocket{
 			Name: "envoy.transport_sockets.tls",

--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -736,6 +736,20 @@ func (c *Controller) translateBackendRefToCluster(defaultNamespace string, backe
 		cluster.LoadAssignment = createClusterLoadAssignment(clusterName, service.Spec.ClusterIP, uint32(*backendRef.Port))
 	}
 
+	if policy := c.lookupBackendTLSPolicy(ns, string(backendRef.Name)); policy != nil {
+		tlsContextAny, err := c.buildUpstreamTLSContext(policy)
+		if err != nil {
+			return nil, fmt.Errorf("invalid BackendTLSPolicy %s/%s for service %s/%s: %w",
+				policy.Namespace, policy.Name, ns, backendRef.Name, err)
+		}
+		cluster.TransportSocket = &corev3.TransportSocket{
+			Name: "envoy.transport_sockets.tls",
+			ConfigType: &corev3.TransportSocket_TypedConfig{
+				TypedConfig: tlsContextAny,
+			},
+		}
+	}
+
 	return cluster, nil
 }
 


### PR DESCRIPTION
- Watch `BackendTLSPolicy` and CA `ConfigMap` objects, and requeue Gateways whose HTTPRoute or GRPCRoute backends are targeted.
- Apply a matching policy to the Envoy upstream cluster: ConfigMap `ca.crt` as the trust bundle, and policy hostname as SNI.
- Oldest policy wins when more than one policy targets the same Service.
