### PR TITLE
Respect HTTPRoute parent statuses for other controllers

### DIFF
--- a/pkg/gateway/gateway.go
+++ b/pkg/gateway/gateway.go
@@ -486,7 +486,15 @@ func (c *Controller) updateRouteStatuses(
 
 			// Create a mutable copy to work with.
 			routeToUpdate := originalRoute.DeepCopy()
-			routeToUpdate.Status.Parents = desiredParentStatuses
+
+			var mergedParents []gatewayv1.RouteParentStatus
+			for _, existing := range routeToUpdate.Status.Parents {
+				if string(existing.ControllerName) != controllerName {
+					mergedParents = append(mergedParents, existing)
+				}
+			}
+			mergedParents = append(mergedParents, desiredParentStatuses...)
+			routeToUpdate.Status.Parents = mergedParents
 
 			// Only make an API call if the status has actually changed.
 			if !semanticIgnoreLastTransitionTime.DeepEqual(originalRoute.Status, routeToUpdate.Status) {


### PR DESCRIPTION
This satisfies upcoming conformance tests in https://github.com/kubernetes-sigs/gateway-api/pull/5206 (issue https://github.com/kubernetes-sigs/gateway-api/issues/5105). With this PR, cpk passes conformance tests on lexfrei's branch.